### PR TITLE
[FEAT] 상세 페이지 제목 공통 컴포넌트 구현

### DIFF
--- a/src/components/detailTitle/DetailTitle.tsx
+++ b/src/components/detailTitle/DetailTitle.tsx
@@ -1,0 +1,22 @@
+import { titleContainerStyle, titleStyle, buttonStyle } from './detailTitle.css';
+
+interface DetailTitleProps {
+  title: string;
+  isTotal?: boolean;
+  onClick?: () => void;
+}
+
+const DetailTitle = ({ title, isTotal = false, onClick }: DetailTitleProps) => {
+  return (
+    <div className={titleContainerStyle}>
+      <p className={titleStyle}>{title}</p>
+      {isTotal && (
+        <button className={buttonStyle} onClick={onClick}>
+          전체보기
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default DetailTitle;

--- a/src/components/detailTitle/detailTitle.css.ts
+++ b/src/components/detailTitle/detailTitle.css.ts
@@ -7,7 +7,6 @@ export const titleContainerStyle = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  border: '1px solid black',
 });
 
 export const titleStyle = style({

--- a/src/components/detailTitle/detailTitle.css.ts
+++ b/src/components/detailTitle/detailTitle.css.ts
@@ -1,0 +1,20 @@
+import theme from '@styles/theme.css';
+import { style } from '@vanilla-extract/css';
+
+export const titleContainerStyle = style({
+  width: '33.5rem',
+  height: '3.3rem',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  border: '1px solid black',
+});
+
+export const titleStyle = style({
+  ...theme.FONTS.h2Sb20,
+});
+
+export const buttonStyle = style({
+  ...theme.FONTS.c6R13,
+  color: theme.COLORS.gray8,
+});

--- a/src/stories/DetailTitle.stories.ts
+++ b/src/stories/DetailTitle.stories.ts
@@ -1,0 +1,47 @@
+import DetailTitle from '@components/detailTitle/DetailTitle';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Common/DetailTitle',
+  component: DetailTitle,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: { type: 'text' },
+      description: 'Title text displayed in the component',
+    },
+    isTotal: {
+      control: { type: 'boolean' },
+      description: 'Determines if the "전체보기" button is shown',
+    },
+    onClick: {
+      action: 'clicked',
+      description: 'Function executed when the button is clicked',
+    },
+  },
+  args: {
+    title: 'Default Title',
+    isTotal: false,
+  },
+} satisfies Meta<typeof DetailTitle>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ReviewButton: Story = {
+  args: {
+    title: '리뷰',
+    isTotal: true,
+    onClick: () => alert('전체보기로 이동'),
+  },
+};
+
+export const WithoutButton: Story = {
+  args: {
+    title: '템플스테이 정보',
+  },
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #60 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 상세 페이지의 제목 공통 컴포넌트 구현했습니다.

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- title이 리뷰이고, 리뷰 개수가 1개 이상일때 전체보기 버튼이 나타나야 해서 어떻게 로직을 짤까 고민했는데 리드님이 말해주신 것처럼 isTotal이라는 boolean값을 true로 받아올 때만 전체보기 버튼이 나타나도록 구현했습니다.

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->
![image](https://github.com/user-attachments/assets/c6159da5-4cb9-4fa9-afb6-2ebc5d3a0206)
하얀색 배경이라 잘 안보여서 border를 잠깐 추가했습니다