### PR TITLE
[FEAT] InfoBtn 컴포넌트 구현

### DIFF
--- a/src/components/common/button/infoBtn/InfoBtn.tsx
+++ b/src/components/common/button/infoBtn/InfoBtn.tsx
@@ -1,0 +1,19 @@
+import Icon from '@assets/svgs';
+import buttonStyle from '@components/common/button/infoBtn/infoBtn.css';
+
+interface InfoBtnProps {
+  label: string;
+  onClick: () => void;
+  hasDivider?: boolean;
+}
+
+const InfoBtn = ({ label, onClick, hasDivider = false }: InfoBtnProps) => {
+  return (
+    <button onClick={onClick} className={buttonStyle({ hasDivider })}>
+      <p>{label} </p>
+      <Icon.IcnArrowGrayRight />
+    </button>
+  );
+};
+
+export default InfoBtn;

--- a/src/components/common/button/infoBtn/infoBtn.css.ts
+++ b/src/components/common/button/infoBtn/infoBtn.css.ts
@@ -13,7 +13,7 @@ const buttonStyle = recipe({
   variants: {
     hasDivider: {
       true: {
-        boxShadow: '0px 1px 0px 0px #EBEDEF',
+        boxShadow: `0px 1px 0px 0px ${theme.COLORS.gray2}`,
       },
       false: {},
     },

--- a/src/components/common/button/infoBtn/infoBtn.css.ts
+++ b/src/components/common/button/infoBtn/infoBtn.css.ts
@@ -1,0 +1,26 @@
+import theme from '@styles/theme.css';
+import { recipe } from '@vanilla-extract/recipes';
+
+const buttonStyle = recipe({
+  base: {
+    backgroundColor: '#fff',
+    ...theme.FONTS.h5Sb16,
+    display: 'flex',
+    justifyContent: 'space-between',
+    width: '31.7rem',
+    padding: '1.6rem 2.3rem 1.6rem 0',
+  },
+  variants: {
+    hasDivider: {
+      true: {
+        boxShadow: '0px 1px 0px 0px #EBEDEF',
+      },
+      false: {},
+    },
+  },
+  defaultVariants: {
+    hasDivider: false,
+  },
+});
+
+export default buttonStyle;

--- a/src/stories/InfoBtn.stories.ts
+++ b/src/stories/InfoBtn.stories.ts
@@ -1,0 +1,33 @@
+import InfoBtn from '@components/common/button/infoBtn/InfoBtn';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Common/Button/InfoBtn',
+  component: InfoBtn,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+    },
+    onClick: {
+      action: 'clicked',
+    },
+    hasDivider: {
+      action: 'boolean',
+    },
+  },
+  args: {
+    label: '공지사항',
+    onClick: () => alert('click !'),
+    hasDivider: true,
+  },
+} satisfies Meta<typeof InfoBtn>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #74 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 마이페이지 InfoBtn 컴포넌트 구현

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 해당 컴포넌트는 마이페이지 > 도움말에서 사용되는 컴포넌트입니다 ! 공지사항, 문의하기 두 개가 있어서 구분선이 필요한데, 이는 hasDivider라는 boolean 값을 이용해 제어하도록 구현했습니다. (hasDivider가 true일 경우 버튼 아래에 구분선을 표시, default는 false) 피그마에서는 구분선이 포함된 형태로 컴포넌트가 정의되어 있지만, 구분선이 없는 경우도 고려해야 했기에 위와 같은 방식으로 작업했습니다 ~~ 더 나은 방법이 있다면 피드백 부탁드림니다 🥸

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->