### PR TITLE
[FEAT] ButtonBar 컴포넌트 퍼블리싱

### DIFF
--- a/src/assets/svgs/icn_reset.svg
+++ b/src/assets/svgs/icn_reset.svg
@@ -1,3 +1,3 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M16.2377 12.1875C15.347 14.9822 12.7959 17 9.78788 17C6.03904 17 3 13.866 3 10C3 6.13401 6.03904 3 9.78788 3C12.3004 3 14.494 4.4077 15.6677 6.5M13.6061 7.375H17V3.875" stroke="#6A7079" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.2377 12.1875C15.347 14.9822 12.7959 17 9.78788 17C6.03904 17 3 13.866 3 10C3 6.13401 6.03904 3 9.78788 3C12.3004 3 14.494 4.4077 15.6677 6.5M13.6061 7.375H17V3.875" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/components/common/button/buttonBar/ButtonBar.tsx
+++ b/src/components/common/button/buttonBar/ButtonBar.tsx
@@ -1,0 +1,40 @@
+import buttonBarContainer from '@components/common/button/buttonBar/buttonBar.css';
+import FlowerBtn from '@components/common/button/flowerBtn/FlowerBtn';
+import PageBottomBtn from '@components/common/button/pageBottom/PageBottomBtn';
+import TextBtn from '@components/common/button/textBtn/TextBtn';
+import { useState } from 'react';
+
+interface ButtonBarProps {
+  type: 'reset' | 'wish';
+}
+
+const ButtonBar = ({ type }: ButtonBarProps) => {
+  const [isActive, setIsActive] = useState(false);
+  const label = type === 'wish' ? '예약하기' : 'NN개의 템플스테이 보기';
+
+  const onClickLefthBtn = () => {
+    setIsActive((prev) => !prev);
+  };
+
+  const renderLeftButton = () =>
+    type === 'wish' ? (
+      <FlowerBtn label="찜하기" isActive={isActive} isLeftIcn onClick={onClickLefthBtn} />
+    ) : (
+      <TextBtn
+        text="초기화"
+        onClick={onClickLefthBtn}
+        leftIcon="IcnReset"
+        size="medium"
+        clicked={isActive}
+      />
+    );
+
+  return (
+    <div className={buttonBarContainer}>
+      {renderLeftButton()}
+      <PageBottomBtn btnText={label} size="small" onClick={() => {}} />
+    </div>
+  );
+};
+
+export default ButtonBar;

--- a/src/components/common/button/buttonBar/ButtonBar.tsx
+++ b/src/components/common/button/buttonBar/ButtonBar.tsx
@@ -1,6 +1,6 @@
 import buttonBarContainer from '@components/common/button/buttonBar/buttonBar.css';
 import FlowerBtn from '@components/common/button/flowerBtn/FlowerBtn';
-import PageBottomBtn from '@components/common/button/pageBottom/PageBottomBtn';
+import PageBottomBtn from '@components/common/button/pageBottomBtn/PageBottomBtn';
 import TextBtn from '@components/common/button/textBtn/TextBtn';
 import { useState } from 'react';
 

--- a/src/components/common/button/buttonBar/ButtonBar.tsx
+++ b/src/components/common/button/buttonBar/ButtonBar.tsx
@@ -6,11 +6,11 @@ import { useState } from 'react';
 
 interface ButtonBarProps {
   type: 'reset' | 'wish';
+  label: string;
 }
 
-const ButtonBar = ({ type }: ButtonBarProps) => {
+const ButtonBar = ({ type, label }: ButtonBarProps) => {
   const [isActive, setIsActive] = useState(false);
-  const label = type === 'wish' ? '예약하기' : 'NN개의 템플스테이 보기';
 
   const onClickLefthBtn = () => {
     setIsActive((prev) => !prev);

--- a/src/components/common/button/buttonBar/buttonBar.css.ts
+++ b/src/components/common/button/buttonBar/buttonBar.css.ts
@@ -1,0 +1,15 @@
+import { style } from '@vanilla-extract/css';
+
+const buttonBarContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '37.5rem',
+  height: '7.2rem',
+  padding: '1rem 2rem',
+  boxSizing: 'border-box',
+
+  boxShadow: `0px -4px 16px 0px rgba(0, 0, 0, 0.05)`,
+});
+
+export default buttonBarContainer;

--- a/src/components/common/button/flowerBtn/FlowerBtn.tsx
+++ b/src/components/common/button/flowerBtn/FlowerBtn.tsx
@@ -1,0 +1,29 @@
+import FlowerIcon from '@components/common/icon/FlowerIcon';
+
+import * as styles from './flowerBtn.css';
+
+interface FlowerBtnProps {
+  isRightIcn?: boolean;
+  isLeftIcn?: boolean;
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+}
+
+const FlowerBtn = ({
+  isRightIcn = false,
+  isLeftIcn = false,
+  label,
+  isActive,
+  onClick,
+}: FlowerBtnProps) => {
+  return (
+    <button className={styles.FlowerBtnStyle} onClick={onClick}>
+      {isLeftIcn && <FlowerIcon isActive={isActive} />}
+      <p className={styles.textStyle({ active: isActive ? true : false })}>{label}</p>
+      {isRightIcn && <FlowerIcon isActive={isActive} />}
+    </button>
+  );
+};
+
+export default FlowerBtn;

--- a/src/components/common/button/flowerBtn/flowerBtn.css.ts
+++ b/src/components/common/button/flowerBtn/flowerBtn.css.ts
@@ -1,0 +1,30 @@
+import theme from '@styles/theme.css';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const FlowerBtnStyle = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: '4.4rem',
+  gap: '0.3rem',
+
+  padding: '0 0.3rem',
+  boxSizing: 'border-box',
+});
+
+export const textStyle = recipe({
+  base: {
+    ...theme.FONTS.b8M15,
+    color: theme.COLORS.gray7,
+  },
+
+  variants: {
+    active: {
+      false: {},
+      true: {
+        color: theme.COLORS.gray10,
+      },
+    },
+  },
+});

--- a/src/components/common/button/pageBottomBtn/PageBottomBtn.tsx
+++ b/src/components/common/button/pageBottomBtn/PageBottomBtn.tsx
@@ -3,11 +3,11 @@ import bottomBtnStyle from './pageBottomBtn.css';
 interface PageBottomBtnProps {
   btnText: string;
   size: 'small' | 'large';
-  isDisabled: boolean;
+  isDisabled?: boolean;
   onClick: () => void;
 }
 
-const PageBottomBtn = ({ btnText, size, isDisabled, onClick }: PageBottomBtnProps) => {
+const PageBottomBtn = ({ btnText, size, isDisabled = false, onClick }: PageBottomBtnProps) => {
   const className = bottomBtnStyle({
     size,
     isDisabled,

--- a/src/components/common/button/textBtn/TextBtn.tsx
+++ b/src/components/common/button/textBtn/TextBtn.tsx
@@ -1,7 +1,6 @@
 import Icon from '@assets/svgs';
-import React from 'react';
 
-import textBtnStyle, { iconStyle } from './textBtn.css';
+import * as styles from './textBtn.css';
 
 interface TextBtnProps {
   clicked?: boolean;
@@ -24,10 +23,10 @@ const TextBtn = ({
   const RightIconComponent = rightIcon ? Icon[rightIcon] : null;
 
   return (
-    <button className={textBtnStyle({ clicked, size })} onClick={onClick}>
-      {LeftIconComponent && <LeftIconComponent className={iconStyle} />}
+    <button className={styles.textBtnStyle({ clicked, size })} onClick={onClick}>
+      {LeftIconComponent && <LeftIconComponent className={styles.iconStyle({ size })} />}
       <span>{text}</span>
-      {RightIconComponent && <RightIconComponent className={iconStyle} />}
+      {RightIconComponent && <RightIconComponent className={styles.iconStyle({ size })} />}
     </button>
   );
 };

--- a/src/components/common/button/textBtn/textBtn.css.ts
+++ b/src/components/common/button/textBtn/textBtn.css.ts
@@ -41,6 +41,11 @@ export const textBtnStyle = recipe({
         color: theme.COLORS.gray7,
         padding: '0 0.8rem',
         ...theme.FONTS.b8M15,
+        selectors: {
+          '&:active': {
+            color: theme.COLORS.gray10,
+          },
+        },
       },
     },
   },
@@ -53,15 +58,6 @@ export const textBtnStyle = recipe({
       },
       style: {
         color: theme.COLORS.gray9,
-      },
-    },
-    {
-      variants: {
-        clicked: true,
-        size: 'medium',
-      },
-      style: {
-        color: theme.COLORS.gray10,
       },
     },
   ],

--- a/src/components/common/button/textBtn/textBtn.css.ts
+++ b/src/components/common/button/textBtn/textBtn.css.ts
@@ -1,35 +1,68 @@
 import theme from '@styles/theme.css';
-import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-export const iconStyle = style({
-  width: '1.3rem',
-  height: '1.3rem',
-  color: 'currentColor',
+export const iconStyle = recipe({
+  base: {
+    color: 'currentColor',
+  },
+  variants: {
+    size: {
+      small: {
+        width: '1.3rem',
+        height: '1.3rem',
+      },
+      medium: {
+        width: '2rem',
+        height: '2rem',
+      },
+    },
+  },
 });
 
-const textBtnStyle = recipe({
+export const textBtnStyle = recipe({
   base: {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
     gap: '0.3rem',
-    ...theme.FONTS.c6R13,
     color: theme.COLORS.gray5,
   },
 
   variants: {
     clicked: {
       false: {},
-      true: {
+      true: {},
+    },
+
+    size: {
+      small: { height: '3.3rem', color: theme.COLORS.gray5, ...theme.FONTS.c6R13 },
+      medium: {
+        height: '4.4rem',
+        color: theme.COLORS.gray7,
+        padding: '0 0.8rem',
+        ...theme.FONTS.b8M15,
+      },
+    },
+  },
+
+  compoundVariants: [
+    {
+      variants: {
+        clicked: true,
+        size: 'small',
+      },
+      style: {
         color: theme.COLORS.gray9,
       },
     },
-    size: {
-      small: { height: '3.3rem' },
-      medium: { height: '4.4rem' },
+    {
+      variants: {
+        clicked: true,
+        size: 'medium',
+      },
+      style: {
+        color: theme.COLORS.gray10,
+      },
     },
-  },
+  ],
 });
-
-export default textBtnStyle;

--- a/src/components/common/icon/FlowerIcon.tsx
+++ b/src/components/common/icon/FlowerIcon.tsx
@@ -1,0 +1,11 @@
+import Icon from '@assets/svgs';
+
+interface FlowerIconProps {
+  isActive?: boolean;
+}
+
+const FlowerIcon = ({ isActive = false }: FlowerIconProps) => {
+  return <>{isActive ? <Icon.IcnFlowerPink /> : <Icon.IcnFlowerGray />}</>;
+};
+
+export default FlowerIcon;

--- a/src/stories/ButtonBar.stories.ts
+++ b/src/stories/ButtonBar.stories.ts
@@ -16,6 +16,7 @@ const meta = {
   },
   args: {
     type: 'wish',
+    label: '예약하기',
   },
 } satisfies Meta<typeof ButtonBar>;
 

--- a/src/stories/ButtonBar.stories.ts
+++ b/src/stories/ButtonBar.stories.ts
@@ -1,0 +1,26 @@
+import ButtonBar from '@components/common/button/buttonBar/ButtonBar';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Common/Button/ButtonBar',
+  component: ButtonBar,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: { type: 'select' },
+      options: ['reset', 'wish'],
+    },
+  },
+  args: {
+    type: 'wish',
+  },
+} satisfies Meta<typeof ButtonBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/FlowerBtn.stories.ts
+++ b/src/stories/FlowerBtn.stories.ts
@@ -1,0 +1,38 @@
+import FlowerBtn from '@components/common/button/flowerBtn/FlowerBtn';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Common/Button/FlowerBtn',
+  component: FlowerBtn,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+    },
+    isRightIcn: {
+      control: { type: 'boolean' },
+    },
+    isLeftIcn: {
+      control: { type: 'boolean' },
+    },
+    isActive: {
+      control: { type: 'boolean' },
+    },
+  },
+  args: {
+    label: '찜하기',
+    isRightIcn: true,
+    isLeftIcn: true,
+    isActive: false,
+    onClick: () => {},
+  },
+} satisfies Meta<typeof FlowerBtn>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #77

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- ButtonBar 컴포넌트 퍼블리싱을 하였습니다.
- flowerBtn 컴포넌트를 구현하였습니다. 
- 기존의 TextBtn이 size에 따라서 색상이 다르게 설정되어서 해당 컴포넌트 스타일을 수정하였습니다.

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- BottomBar 버튼이 reset인 경우와 wish인 경우 2가지로 나누었는데 확장성이 떨어진다고 생각이 들긴하지만 일단 이렇게 만들었습니다. 더 좋은 방식이 있다고 생각하시면 말씀해주세요!

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->
- bottomBtn
<img width="429" alt="image" src="https://github.com/user-attachments/assets/5ba590ff-80f6-4037-a25d-d6a7d8ee5929" />

- flowerBtn
<img width="126" alt="image" src="https://github.com/user-attachments/assets/6ccd30e8-bd2b-49de-8fe9-906569606a8b" />
