### PR TITLE
[FEAT] router 세팅

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "@vanilla-extract/vite-plugin": "^4.0.19",
     "axios": "^1.7.9",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.1.1"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,11 @@
+import { Outlet } from 'react-router-dom';
+
 const App = () => {
-  return <div></div>;
+  return (
+    <main style={{ margin: '0 auto' }}>
+      <Outlet />
+    </main>
+  );
 };
 
 export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,18 +2,19 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import Router from 'src/router/Router.tsx';
+
 import '@styles/reset.css.ts';
 import '@styles/global.css.ts';
 import '@styles/fonts.css.ts';
 
-import App from './App.tsx';
 import queryClient from './queryClient.ts';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <ReactQueryDevtools initialIsOpen={false} />
-      <App />
+      <Router />
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,0 +1,5 @@
+const ErrorPage = () => {
+  return <div>ErrorPage</div>;
+};
+
+export default ErrorPage;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,5 @@
+const HomePage = () => {
+  return <div>HomePage</div>;
+};
+
+export default HomePage;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,0 +1,5 @@
+const SearchPage = () => {
+  return <div>SearchPage</div>;
+};
+
+export default SearchPage;

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,0 +1,39 @@
+import { lazy, Suspense } from 'react';
+import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom';
+import App from 'src/App';
+
+const HomePage = lazy(() => import('@pages/HomePage'));
+const SearchPage = lazy(() => import('@pages/SearchPage'));
+const ErrorPage = lazy(() => import('@pages/ErrorPage'));
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+    errorElement: <ErrorPage />,
+    children: [
+      {
+        index: true,
+        element: <HomePage />,
+      },
+      {
+        path: 'search',
+        element: <SearchPage />,
+      },
+    ],
+  },
+
+  {
+    path: '*',
+    element: <Navigate to="/" replace />,
+  },
+]);
+
+// TODO: 로딩 화면 추가
+const Router = () => (
+  <Suspense fallback={<div>로딩 화면 추가</div>}>
+    <RouterProvider router={router} />
+  </Suspense>
+);
+
+export default Router;

--- a/src/styles/global.css.ts
+++ b/src/styles/global.css.ts
@@ -11,10 +11,14 @@ globalStyle('html, body', {
 });
 
 globalStyle('#root', {
+  display: 'flex',
+  flexDirection: 'column',
+
   width: '100%',
   maxWidth: '37.5rem',
   minHeight: '100dvh',
   margin: '0 auto',
+  paddingTop: '1.2rem',
 });
 
 globalStyle('body, button, input, select, table, textarea', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,6 +1344,11 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
+"@types/cookie@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
+  integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
+
 "@types/doctrine@^0.0.9":
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/@types/doctrine/-/doctrine-0.0.9.tgz#d86a5f452a15e3e3113b99e39616a9baa0f9863f"
@@ -2064,6 +2069,11 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cookie@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
+  integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
 
 cosmiconfig@^8.1.3:
   version "8.3.6"
@@ -3863,6 +3873,23 @@ react-refresh@^0.14.2:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
 
+react-router-dom@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.1.1.tgz#9e76fb63a762ba5da13032f5fd9e4a24946396b6"
+  integrity sha512-vSrQHWlJ5DCfyrhgo0k6zViOe9ToK8uT5XGSmnuC2R3/g261IdIMpZVqfjD6vWSXdnf5Czs4VA/V60oVR6/jnA==
+  dependencies:
+    react-router "7.1.1"
+
+react-router@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.1.1.tgz#88f5657fa5b8f0b918c7222ec710de0274d00b2e"
+  integrity sha512-39sXJkftkKWRZ2oJtHhCxmoCrBCULr/HAH4IT5DHlgu/Q0FCPV0S4Lx+abjDTx/74xoZzNYDYbOZWlJjruyuDQ==
+  dependencies:
+    "@types/cookie" "^0.6.0"
+    cookie "^1.0.1"
+    set-cookie-parser "^2.6.0"
+    turbo-stream "2.4.0"
+
 "react@^16.8.0 || ^17.0.0 || ^18.0.0", react@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
@@ -4058,6 +4085,11 @@ semver@^7.6.0, semver@^7.6.2:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+
+set-cookie-parser@^2.6.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz#3016f150072202dfbe90fadee053573cc89d2943"
+  integrity sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -4342,6 +4374,11 @@ tslib@^2.0.1, tslib@^2.0.3, tslib@^2.6.2:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+turbo-stream@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/turbo-stream/-/turbo-stream-2.4.0.tgz#1e4fca6725e90fa14ac4adb782f2d3759a5695f0"
+  integrity sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==
 
 tween-functions@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #81

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- router 세팅을 진행하였습니다.
- lazy를 통해 페이지 컴포넌트를 동적으로 로드하여 초기 번들 크기를 줄이고 필요할 때만 해당 모듈을 가져오도록 하였습니다.
- lazy로 로드된 컴포넌트를 suspense로 감싸서 컴포넌트가 로드될 때까지 사용자에게 로딩 화면을 보여주도록 하였습니다.
- outlet에 margin: 0 auto를 주어서 해당 컴포넌트가 화면의 가운데에 위치할 수 있도록 하였습니다.
- 디자인 선생님들께 말씀 드려서 페이지의 margin-top은 12px로 고정해놔서 해당 값도 함께 추가하였습니다.
- 유효하지 않은 url주소로 갈시 main으로 리다이렉트되도록 설정하였습니다.

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- header와 footer가 반복적으로 사용되었다면 app에 header와 footer를 지정해 놓거나, header와 footer를 따로 받아서 children으로 넣을지에 대해서 고민해보았는데 화면마다 헤더의 값에 서버 데이터가 들어가기도 하고, header는 화면중에 1번, footer은 2개의 화면에만 존재해서 각 화면에서 정의하는 것이 나을것이라 생각하여 header와 footer를 공통적으로 app에 정의하지 않았습니다.

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->


## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
https://codeparrot.ai/blogs/createbrowserrouter-a-step-up-from-switch
https://hihiha2.tistory.com/164

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->
