### PR TITLE
[FEAT] 큐레이션 캐러셀 퍼블리싱

### DIFF
--- a/src/components/carousel/curationCarousel/CurationCarousel.tsx
+++ b/src/components/carousel/curationCarousel/CurationCarousel.tsx
@@ -1,0 +1,59 @@
+import CurationCard from '@components/curation/curationCard/CurationCard';
+import CURATION_INFO from '@constants/curationInfo';
+import registDragEvent from '@utils/registDragEvent';
+import { useState, useRef } from 'react';
+
+import * as styles from './curationCarousel.css';
+
+const CurationCarousel = () => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [transX, setTransX] = useState(0);
+  const carouselRef = useRef<HTMLDivElement>(null);
+
+  const moveDistance = 295; // carousel card width + gap
+
+  return (
+    <section ref={carouselRef} className={styles.carouselWrapper}>
+      <div className={styles.emptyBox} />
+      <div
+        className={styles.carouselContainer}
+        style={{
+          transform: `translateX(${-currentIndex * moveDistance + transX}px)`,
+          transition: `transform 200ms ease-in-out 0s`,
+        }}
+        {...registDragEvent({
+          onDragChange: (deltaX) => {
+            setTransX(deltaX);
+          },
+          onDragEnd: (deltaX) => {
+            const maxIndex = CURATION_INFO.length - 1;
+
+            // 드래그를 왼쪽으로 넘겼을 때
+            if (deltaX < -100) {
+              setCurrentIndex(currentIndex + 1 > maxIndex ? maxIndex : currentIndex + 1);
+            }
+            // 드래그를 오른쪽으로 넘겼을 때
+            if (deltaX > 100) {
+              setCurrentIndex(currentIndex - 1 < 0 ? 0 : currentIndex - 1);
+            }
+
+            setTransX(0);
+          },
+        })}>
+        {CURATION_INFO.map((data, index) => (
+          <CurationCard
+            key={index}
+            bgImage={data.bgImage}
+            title={data.title}
+            subtitle={data.subtitle}
+            onClick={() => {
+              data.onClick();
+            }}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default CurationCarousel;

--- a/src/components/carousel/curationCarousel/curationCarousel.css.ts
+++ b/src/components/carousel/curationCarousel/curationCarousel.css.ts
@@ -1,0 +1,23 @@
+import { style } from '@vanilla-extract/css';
+
+export const emptyBox = style({
+  width: '2rem',
+  height: '100%',
+  flexShrink: 0,
+});
+
+export const carouselWrapper = style({
+  width: '37.5rem',
+  overflow: 'hidden',
+  display: 'flex',
+  marginLeft: '-2rem',
+});
+
+export const carouselContainer = style({
+  display: 'flex',
+  gap: '1rem',
+});
+
+export const carouselItem = style({
+  flexShrink: 0,
+});

--- a/src/components/curation/curationCard/curationCard.css.ts
+++ b/src/components/curation/curationCard/curationCard.css.ts
@@ -10,6 +10,7 @@ export const cardContainer = style({
   backgroundPosition: 'center',
   display: 'flex',
   alignItems: 'flex-end',
+  flexShrink: 0,
 
   padding: '1.6rem',
   color: theme.COLORS.white,

--- a/src/components/search/recentBtn/recentBtnBox.css.ts
+++ b/src/components/search/recentBtn/recentBtnBox.css.ts
@@ -1,0 +1,25 @@
+import theme from '@styles/theme.css';
+import { style } from '@vanilla-extract/css';
+
+export const recentBtnBox = style({
+  display: 'flex',
+  width: 'calc(100% - 2rem)',
+  gap: '0.8rem',
+  marginTop: '0.8rem',
+
+  overflowX: 'auto',
+  whiteSpace: 'nowrap',
+
+  selectors: {
+    '&::-webkit-scrollbar': {
+      display: 'none',
+    },
+  },
+});
+
+export const emptyResult = style({
+  margin: '3.2rem 0 0 10rem',
+
+  color: theme.COLORS.gray7,
+  ...theme.FONTS.c2R14,
+});

--- a/src/constants/curationInfo.ts
+++ b/src/constants/curationInfo.ts
@@ -1,0 +1,28 @@
+const CURATION_INFO = [
+  {
+    bgImage: 'https://img.danawa.com/images/descFiles/6/110/5109431_agiLaciMHn_1659098198501.jpeg',
+    title: '1번',
+    subtitle: 'subtitle',
+    onClick: () => alert('1번 큐레이션 클릭'),
+  },
+  {
+    bgImage: 'https://img.danawa.com/images/descFiles/6/110/5109431_agiLaciMHn_1659098198501.jpeg',
+    title: '2번',
+    subtitle: 'subtitle',
+    onClick: () => alert('2번 큐레이션 클릭'),
+  },
+  {
+    bgImage: 'https://img.danawa.com/images/descFiles/6/110/5109431_agiLaciMHn_1659098198501.jpeg',
+    title: '3번',
+    subtitle: 'subtitle',
+    onClick: () => alert('3번 큐레이션 클릭'),
+  },
+  {
+    bgImage: 'https://img.danawa.com/images/descFiles/6/110/5109431_agiLaciMHn_1659098198501.jpeg',
+    title: '4번',
+    subtitle: 'subtitle',
+    onClick: () => alert('4번 큐레이션 클릭'),
+  },
+];
+
+export default CURATION_INFO;

--- a/src/stories/CurationCarousel.stories.ts
+++ b/src/stories/CurationCarousel.stories.ts
@@ -1,0 +1,17 @@
+import CurationCarousel from '@components/carousel/curationCarousel/CurationCarousel';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Carousel/CurationCarousel',
+  component: CurationCarousel,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof CurationCarousel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/styles/global.css.ts
+++ b/src/styles/global.css.ts
@@ -19,8 +19,6 @@ globalStyle('#root', {
   minHeight: '100dvh',
   margin: '0 auto',
   padding: '1.2rem 2rem 0',
-  background: 'beige',
-  paddingTop: '1.2rem',
 });
 
 globalStyle('body, button, input, select, table, textarea', {

--- a/src/styles/global.css.ts
+++ b/src/styles/global.css.ts
@@ -15,6 +15,8 @@ globalStyle('#root', {
   maxWidth: '37.5rem',
   minHeight: '100dvh',
   margin: '0 auto',
+  padding: '1.2rem 2rem 0',
+  background: 'beige',
 });
 
 globalStyle('body, button, input, select, table, textarea', {

--- a/src/utils/registDragEvent.ts
+++ b/src/utils/registDragEvent.ts
@@ -1,0 +1,32 @@
+const registDragEvent = ({
+  onDragChange,
+  onDragEnd,
+  stopPropagation,
+}: {
+  onDragChange?: (dx: number, dy: number) => void;
+  onDragEnd?: (dx: number, dy: number) => void;
+  stopPropagation?: boolean;
+}) => ({
+  onMouseDown: (clickEvent: React.MouseEvent<Element, MouseEvent>) => {
+    if (stopPropagation) clickEvent.stopPropagation(); // 부모로 클릭 이벤트 전달 안 되도록
+
+    // 마우스 이동거리 계산
+    const mouseMoveHandler = (moveEvent: MouseEvent) => {
+      const dx = moveEvent.pageX - clickEvent.pageX;
+      const dy = moveEvent.pageY - clickEvent.pageY;
+      onDragChange?.(dx, dy);
+    };
+
+    const mouseUpHandler = (moveEvent: MouseEvent) => {
+      const dx = moveEvent.pageX - clickEvent.pageX;
+      const dy = moveEvent.pageY - clickEvent.pageY;
+      onDragEnd?.(dx, dy);
+      document.removeEventListener('mousemove', mouseMoveHandler);
+    };
+
+    document.addEventListener('mousemove', mouseMoveHandler);
+    document.addEventListener('mouseup', mouseUpHandler, { once: true });
+  },
+});
+
+export default registDragEvent;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #82 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 홈페이지 > 큐레이션 캐러셀 퍼블리싱 완료했습니다
- 일정 거리 이상 드래그 되면 다음 큐레이션 카드로 넘어가도록 구현했습니다
- 큐레이션 관련 데이터는 서버에서 받아오는 것이 아니기 때문에 , constant 폴더에 따로 빼두었습니다.

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 해당 섹션의 타이틀(절로가 큐레이션)을 캐러셀 컴포넌트 안에 포함시킬지 말지 고민중입니닷
- 아래 첨부한 아티클을 많이 참고했는데, 드래그 이벤트 관리하는 함수를 빼두는 게 다른 캐러셀에서도 사용할 수 있을 것 같아 유틸로 만들어두었습니다 , ,
- 해당 캐러셀의 경우 `드래그 -> 캐러셀 이동`, `클릭 -> 큐레이션 페이지로 이동` 의 두 가지 조건을 모두 만족해야 했기 때문에, 100을 기준으로 드래그 / 클릭을 구분하였습니다 ! 여러 값으로 테스트 해본 결과 가장 적당하다고 판단해서 100을 기준으로 하였는데 너무 낮거나 높다고 생각되면 피드백 부탁드립니다. 

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- [Drag Carousel 뽀개기](https://velog.io/@bepyan/Drag-Carousel-%EB%BD%80%EA%B0%9C%EA%B8%B0)
- [[JS] 클릭과 드래그 이벤트 구분하기(React)](https://velog.io/@postlist/JS-%ED%81%B4%EB%A6%AD%EA%B3%BC-%EB%93%9C%EB%9E%98%EA%B7%B8-%EC%9D%B4%EB%B2%A4%ED%8A%B8-%EA%B5%AC%EB%B6%84%ED%95%98%EA%B8%B0React)
## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->