### PR TITLE
[FEAT] 인기스테이 캐러셀 구현

### DIFF
--- a/src/components/carousel/curationCarousel/CurationCarousel.tsx
+++ b/src/components/carousel/curationCarousel/CurationCarousel.tsx
@@ -1,44 +1,26 @@
 import CurationCard from '@components/curation/curationCard/CurationCard';
 import CURATION_INFO from '@constants/curationInfo';
+import useCarousel from '@hooks/useCarousel';
 import registDragEvent from '@utils/registDragEvent';
-import { useState, useRef } from 'react';
+import React from 'react';
 
 import * as styles from './curationCarousel.css';
 
 const CurationCarousel = () => {
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [transX, setTransX] = useState(0);
-  const carouselRef = useRef<HTMLDivElement>(null);
-
-  const moveDistance = 295; // carousel card width + gap
+  const { carouselRef, transformStyle, handleDragChange, handleDragEnd } = useCarousel({
+    itemCount: CURATION_INFO.length,
+    moveDistance: 295,
+  });
 
   return (
     <section ref={carouselRef} className={styles.carouselWrapper}>
       <div className={styles.emptyBox} />
       <div
         className={styles.carouselContainer}
-        style={{
-          transform: `translateX(${-currentIndex * moveDistance + transX}px)`,
-          transition: `transform 200ms ease-in-out 0s`,
-        }}
+        style={transformStyle}
         {...registDragEvent({
-          onDragChange: (deltaX) => {
-            setTransX(deltaX);
-          },
-          onDragEnd: (deltaX) => {
-            const maxIndex = CURATION_INFO.length - 1;
-
-            // 드래그를 왼쪽으로 넘겼을 때
-            if (deltaX < -100) {
-              setCurrentIndex(currentIndex + 1 > maxIndex ? maxIndex : currentIndex + 1);
-            }
-            // 드래그를 오른쪽으로 넘겼을 때
-            if (deltaX > 100) {
-              setCurrentIndex(currentIndex - 1 < 0 ? 0 : currentIndex - 1);
-            }
-
-            setTransX(0);
-          },
+          onDragChange: handleDragChange,
+          onDragEnd: handleDragEnd,
         })}>
         {CURATION_INFO.map((data, index) => (
           <CurationCard
@@ -46,9 +28,7 @@ const CurationCarousel = () => {
             bgImage={data.bgImage}
             title={data.title}
             subtitle={data.subtitle}
-            onClick={() => {
-              data.onClick();
-            }}
+            onClick={data.onClick}
           />
         ))}
       </div>

--- a/src/components/carousel/popularCarousel/CarouselIndex.tsx
+++ b/src/components/carousel/popularCarousel/CarouselIndex.tsx
@@ -1,0 +1,22 @@
+import indexStyle, { indexContainer } from '@components/carousel/popularCarousel/carouselIndex.css';
+import React from 'react';
+
+interface CarouselIndexProps {
+  total: number;
+  currentIndex: number;
+}
+
+const CarouselIndex = ({ total, currentIndex }: CarouselIndexProps) => {
+  return (
+    <div className={indexContainer}>
+      {Array.from({ length: total }).map((_, index) => (
+        <div
+          key={index}
+          className={indexStyle({ state: index === currentIndex ? 'active' : 'inactive' })}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default CarouselIndex;

--- a/src/components/carousel/popularCarousel/PopularCarousel.tsx
+++ b/src/components/carousel/popularCarousel/PopularCarousel.tsx
@@ -1,6 +1,7 @@
 import PopularCard from '@components/card/popularCard/PopularCard';
+import useCarousel from '@hooks/useCarousel';
 import registDragEvent from '@utils/registDragEvent';
-import React, { useState, useRef } from 'react';
+import React from 'react';
 
 import * as styles from './popularCarousel.css';
 
@@ -37,54 +38,33 @@ const stayData = {
 };
 
 const PopularCarousel = () => {
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [transX, setTransX] = useState(0);
-  const carouselRef = useRef<HTMLDivElement>(null);
-
-  const moveDistance = 355;
+  const { carouselRef, transformStyle, handleDragChange, handleDragEnd } = useCarousel({
+    itemCount: stayData.rankings.length,
+    moveDistance: 355,
+  });
 
   return (
     <section ref={carouselRef} className={styles.carouselWrapper}>
       <div
         className={styles.carouselContainer}
-        style={{
-          transform: `translateX(${-currentIndex * moveDistance + transX}px)`,
-          transition: `transform 200ms ease-in-out 0s`,
-        }}
+        style={transformStyle}
         {...registDragEvent({
-          onDragChange: (deltaX) => {
-            setTransX(deltaX);
-          },
-          onDragEnd: (deltaX) => {
-            const maxIndex = stayData.rankings.length - 1;
-
-            // 드래그를 왼쪽으로 넘겼을 때
-            if (deltaX < -100) {
-              setCurrentIndex(currentIndex + 1 > maxIndex ? maxIndex : currentIndex + 1);
-            }
-            // 드래그를 오른쪽으로 넘겼을 때
-            if (deltaX > 100) {
-              setCurrentIndex(currentIndex - 1 < 0 ? 0 : currentIndex - 1);
-            }
-
-            setTransX(0);
-          },
+          onDragChange: handleDragChange,
+          onDragEnd: handleDragEnd,
         })}>
-        {stayData.rankings.map((data, id) => (
-          <>
-            <PopularCard
-              key={id}
-              ranking={data.ranking}
-              templeName={data.templeName}
-              templeLoc={data.region}
-              templeImg={data.imgUrl}
-              isLiked={data.liked}
-              tag={data.tag}
-              onClick={() => {
-                alert(`${data.templeName} 클릭됨!`);
-              }}
-            />
-          </>
+        {stayData.rankings.map((data) => (
+          <PopularCard
+            key={data.id}
+            ranking={data.ranking}
+            templeName={data.templeName}
+            templeLoc={data.region}
+            templeImg={data.imgUrl}
+            isLiked={data.liked}
+            tag={data.tag}
+            onClick={() => {
+              alert(`${data.templeName} 클릭됨!`);
+            }}
+          />
         ))}
       </div>
     </section>

--- a/src/components/carousel/popularCarousel/PopularCarousel.tsx
+++ b/src/components/carousel/popularCarousel/PopularCarousel.tsx
@@ -1,0 +1,92 @@
+import PopularCard from '@components/card/popularCard/PopularCard';
+import registDragEvent from '@utils/registDragEvent';
+import React, { useState, useRef } from 'react';
+
+import * as styles from './popularCarousel.css';
+
+const stayData = {
+  rankings: [
+    {
+      ranking: 1,
+      id: 1,
+      templeName: '대원사(보성)',
+      tag: '방긋방긋',
+      region: '전남',
+      liked: true,
+      imgUrl: 'http://noms.templestay.com/images//RsImage/L_13774.png',
+    },
+    {
+      ranking: 2,
+      id: 2,
+      templeName: '수원사',
+      tag: '방긋방긋',
+      region: '경기',
+      liked: true,
+      imgUrl: 'http://noms.templestay.com/images//RsImage/L_13774.png',
+    },
+    {
+      ranking: 3,
+      id: 3,
+      templeName: '용흥사',
+      tag: '방긋방긋',
+      region: '전남',
+      liked: false,
+      imgUrl: 'http://noms.templestay.com/images//RsImage/L_13774.png',
+    },
+  ],
+};
+
+const PopularCarousel = () => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [transX, setTransX] = useState(0);
+  const carouselRef = useRef<HTMLDivElement>(null);
+
+  const moveDistance = 335;
+
+  return (
+    <section ref={carouselRef} className={styles.carouselWrapper}>
+      <div
+        className={styles.carouselContainer}
+        style={{
+          transform: `translateX(${-currentIndex * moveDistance + transX}px)`,
+          transition: `transform 200ms ease-in-out 0s`,
+        }}
+        {...registDragEvent({
+          onDragChange: (deltaX) => {
+            setTransX(deltaX);
+          },
+          onDragEnd: (deltaX) => {
+            const maxIndex = stayData.rankings.length - 1;
+
+            // 드래그를 왼쪽으로 넘겼을 때
+            if (deltaX < -100) {
+              setCurrentIndex(currentIndex + 1 > maxIndex ? maxIndex : currentIndex + 1);
+            }
+            // 드래그를 오른쪽으로 넘겼을 때
+            if (deltaX > 100) {
+              setCurrentIndex(currentIndex - 1 < 0 ? 0 : currentIndex - 1);
+            }
+
+            setTransX(0);
+          },
+        })}>
+        {stayData.rankings.map((data, id) => (
+          <PopularCard
+            key={id}
+            ranking={data.ranking}
+            templeName={data.templeName}
+            templeLoc={data.region}
+            templeImg={data.imgUrl}
+            isLiked={data.liked}
+            tag={data.tag}
+            onClick={() => {
+              console.log(`${data.templeName} 클릭됨!`);
+            }}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default PopularCarousel;

--- a/src/components/carousel/popularCarousel/PopularCarousel.tsx
+++ b/src/components/carousel/popularCarousel/PopularCarousel.tsx
@@ -41,7 +41,7 @@ const PopularCarousel = () => {
   const [transX, setTransX] = useState(0);
   const carouselRef = useRef<HTMLDivElement>(null);
 
-  const moveDistance = 335;
+  const moveDistance = 355;
 
   return (
     <section ref={carouselRef} className={styles.carouselWrapper}>
@@ -71,18 +71,20 @@ const PopularCarousel = () => {
           },
         })}>
         {stayData.rankings.map((data, id) => (
-          <PopularCard
-            key={id}
-            ranking={data.ranking}
-            templeName={data.templeName}
-            templeLoc={data.region}
-            templeImg={data.imgUrl}
-            isLiked={data.liked}
-            tag={data.tag}
-            onClick={() => {
-              console.log(`${data.templeName} 클릭됨!`);
-            }}
-          />
+          <>
+            <PopularCard
+              key={id}
+              ranking={data.ranking}
+              templeName={data.templeName}
+              templeLoc={data.region}
+              templeImg={data.imgUrl}
+              isLiked={data.liked}
+              tag={data.tag}
+              onClick={() => {
+                alert(`${data.templeName} 클릭됨!`);
+              }}
+            />
+          </>
         ))}
       </div>
     </section>

--- a/src/components/carousel/popularCarousel/carouselIndex.css.ts
+++ b/src/components/carousel/popularCarousel/carouselIndex.css.ts
@@ -1,0 +1,30 @@
+import theme from '@styles/theme.css';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+const indexStyle = recipe({
+  base: {
+    width: '0.6rem',
+    height: '0.6rem',
+    borderRadius: '100%',
+    backgroundColor: theme.COLORS.gray3,
+  },
+  variants: {
+    state: {
+      active: {
+        backgroundColor: theme.COLORS.gray11,
+      },
+      inactive: {},
+    },
+  },
+  defaultVariants: {
+    state: 'inactive',
+  },
+});
+
+export const indexContainer = style({
+  display: 'flex',
+  gap: '0.4rem',
+});
+
+export default indexStyle;

--- a/src/components/carousel/popularCarousel/popularCarousel.css.ts
+++ b/src/components/carousel/popularCarousel/popularCarousel.css.ts
@@ -8,8 +8,15 @@ export const carouselWrapper = style({
 
 export const carouselContainer = style({
   display: 'flex',
+  gap: '2rem',
 });
 
 export const carouselItem = style({
+  flexShrink: 0,
+});
+
+export const emptyBox = style({
+  width: '2rem',
+  height: '100%',
   flexShrink: 0,
 });

--- a/src/components/carousel/popularCarousel/popularCarousel.css.ts
+++ b/src/components/carousel/popularCarousel/popularCarousel.css.ts
@@ -1,0 +1,15 @@
+import { style } from '@vanilla-extract/css';
+
+export const carouselWrapper = style({
+  width: '33.5rem',
+  overflow: 'hidden',
+  display: 'flex',
+});
+
+export const carouselContainer = style({
+  display: 'flex',
+});
+
+export const carouselItem = style({
+  flexShrink: 0,
+});

--- a/src/hooks/useCarousel.ts
+++ b/src/hooks/useCarousel.ts
@@ -1,0 +1,45 @@
+import { useState, useRef } from 'react';
+
+interface UseCarouselProps {
+  itemCount: number; // 캐러셀 항목 개수
+  moveDistance: number; // 이동 거리
+}
+
+const useCarousel = ({ itemCount, moveDistance }: UseCarouselProps) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [transX, setTransX] = useState(0);
+  const carouselRef = useRef<HTMLDivElement>(null);
+
+  const handleDragChange = (deltaX: number) => {
+    setTransX(deltaX);
+  };
+
+  const handleDragEnd = (deltaX: number) => {
+    const maxIndex = itemCount - 1;
+
+    if (deltaX < -100) {
+      // 왼쪽으로 드래그
+      setCurrentIndex(currentIndex + 1 > maxIndex ? maxIndex : currentIndex + 1);
+    } else if (deltaX > 100) {
+      // 오른쪽으로 드래그
+      setCurrentIndex(currentIndex - 1 < 0 ? 0 : currentIndex - 1);
+    }
+
+    setTransX(0);
+  };
+
+  const transformStyle = {
+    transform: `translateX(${-currentIndex * moveDistance + transX}px)`,
+    transition: 'transform 200ms ease-in-out 0s',
+  };
+
+  return {
+    currentIndex,
+    carouselRef,
+    transformStyle,
+    handleDragChange,
+    handleDragEnd,
+  };
+};
+
+export default useCarousel;

--- a/src/stories/CarouselIndex.stories.ts
+++ b/src/stories/CarouselIndex.stories.ts
@@ -1,0 +1,29 @@
+import CarouselIndex from '@components/carousel/popularCarousel/CarouselIndex';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Carousel/PopularCarousel/CarouselIndex',
+  component: CarouselIndex,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    total: {
+      control: { type: 'number' },
+    },
+    currentIndex: {
+      control: { type: 'number' },
+    },
+  },
+  args: {
+    total: 3,
+    currentIndex: 2,
+  },
+} satisfies Meta<typeof CarouselIndex>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/PopularCarousel.stories.ts
+++ b/src/stories/PopularCarousel.stories.ts
@@ -1,0 +1,17 @@
+import PopularCarousel from '@components/carousel/popularCarousel/PopularCarousel';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Carousel/PopularCarousel',
+  component: PopularCarousel,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PopularCarousel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/PopularCarousel.stories.ts
+++ b/src/stories/PopularCarousel.stories.ts
@@ -2,7 +2,7 @@ import PopularCarousel from '@components/carousel/popularCarousel/PopularCarouse
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta = {
-  title: 'Carousel/PopularCarousel',
+  title: 'Carousel/PopularCarousel/PopularCarousel',
   component: PopularCarousel,
   parameters: {
     layout: 'centered',

--- a/src/styles/global.css.ts
+++ b/src/styles/global.css.ts
@@ -19,7 +19,6 @@ globalStyle('#root', {
   maxWidth: '37.5rem',
   minHeight: '100dvh',
   margin: '0 auto',
-  // padding: '1.2rem 2rem 0',
   paddingTop: '1.2rem',
 });
 

--- a/src/styles/global.css.ts
+++ b/src/styles/global.css.ts
@@ -19,7 +19,8 @@ globalStyle('#root', {
   maxWidth: '37.5rem',
   minHeight: '100dvh',
   margin: '0 auto',
-  padding: '1.2rem 2rem 0',
+  // padding: '1.2rem 2rem 0',
+  paddingTop: '1.2rem',
 });
 
 globalStyle('body, button, input, select, table, textarea', {

--- a/src/utils/registDragEvent.ts
+++ b/src/utils/registDragEvent.ts
@@ -27,6 +27,25 @@ const registDragEvent = ({
     document.addEventListener('mousemove', mouseMoveHandler);
     document.addEventListener('mouseup', mouseUpHandler, { once: true });
   },
+  onTouchStart: (touchEvent: React.TouchEvent<Element>) => {
+    if (stopPropagation) touchEvent.stopPropagation();
+
+    const touchMoveHandler = (moveEvent: TouchEvent) => {
+      const dx = moveEvent.touches[0].pageX - touchEvent.touches[0].pageX;
+      const dy = moveEvent.touches[0].pageY - touchEvent.touches[0].pageY;
+      onDragChange?.(dx, dy);
+    };
+
+    const touchEndHandler = (endEvent: TouchEvent) => {
+      const dx = endEvent.changedTouches[0].pageX - touchEvent.touches[0].pageX;
+      const dy = endEvent.changedTouches[0].pageY - touchEvent.touches[0].pageY;
+      onDragEnd?.(dx, dy);
+      document.removeEventListener('touchmove', touchMoveHandler);
+    };
+
+    document.addEventListener('touchmove', touchMoveHandler);
+    document.addEventListener('touchend', touchEndHandler, { once: true });
+  },
 });
 
 export default registDragEvent;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #100 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 인기스테이 캐러셀 퍼블리싱 완료했습니다.
- 해당 캐러셀 컴포넌트 아래에 위치한 캐러셀 인덱스 퍼블리싱 완료했습니다 (합치는 건 페이지 퍼블리싱에서 할 예정)
- 캐러셀 컴포넌트를 구현할 때 사용할 수 있는 useCarousel 커스텀 훅을 작성하였습니다 ! 전체적으로 상태를 관리하고, 드래그 동작을 처리하며, 스타일과 동작을 제어하는 로직들을 분리해두었습니당 ~

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- registDragEvent 함수에 touch 이벤트(onTouchStart, onTouchMove, onTouchEnd) 처리 로직 추가 -> 데스크톱과 모바일 모두에서 캐러셀 동작 가능하도록 수정하였습니다

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- Mouse Evenㅅ와 Touch Event의 차이점에 대해 알게되었습니다.
- 모바일 웹에서는 Touch Event까지 함께 관리해주어야 한다는 점을 알게 되었습니다 , , ,

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- [[Web] Mouse Event, Touch Event, Pointer Event, Drag Event 비교](https://velog.io/@jsi06138/Web-Mouse-Drag-Pointer)

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->