### PR TITLE
[FEAT] 사용자 닉네임 반환, 온보딩 정보 전송 api 연결

### DIFF
--- a/src/apis/user/axios.ts
+++ b/src/apis/user/axios.ts
@@ -1,0 +1,14 @@
+import { privateInstance } from '@apis/instance';
+
+import { UserNicknameResponse } from './type';
+
+const fetchUserNickname = async (userId: number): Promise<UserNicknameResponse> => {
+  const response = await privateInstance.get<UserNicknameResponse>(`/user/register/success`, {
+    params: {
+      userId,
+    },
+  });
+  return response.data;
+};
+
+export default fetchUserNickname;

--- a/src/apis/user/axios.ts
+++ b/src/apis/user/axios.ts
@@ -1,8 +1,8 @@
 import { privateInstance } from '@apis/instance';
 
-import { UserNicknameResponse } from './type';
+import { OnboardingUserRequest, UserNicknameResponse } from './type';
 
-const fetchUserNickname = async (userId: number): Promise<UserNicknameResponse> => {
+export const fetchUserNickname = async (userId: number): Promise<UserNicknameResponse> => {
   const response = await privateInstance.get<UserNicknameResponse>(`/user/register/success`, {
     params: {
       userId,
@@ -11,4 +11,6 @@ const fetchUserNickname = async (userId: number): Promise<UserNicknameResponse> 
   return response.data;
 };
 
-export default fetchUserNickname;
+export const registerUser = async (data: OnboardingUserRequest): Promise<void> => {
+  await privateInstance.post('/user/register', data);
+};

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -1,0 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { registerUser } from './axios';
+import { OnboardingUserRequest } from './type';
+
+const useRegisterUser = () => {
+  return useMutation<void, Error, OnboardingUserRequest>({
+    mutationFn: (data) => registerUser(data),
+  });
+};
+
+export default useRegisterUser;

--- a/src/apis/user/type.ts
+++ b/src/apis/user/type.ts
@@ -1,3 +1,11 @@
 export interface UserNicknameResponse {
   nickname: string;
 }
+
+export interface OnboardingUserRequest {
+  userId: number;
+  ageRange: string | null;
+  gender: string | null;
+  religion: string | null;
+  hasExperience: string | null;
+}

--- a/src/apis/user/type.ts
+++ b/src/apis/user/type.ts
@@ -1,0 +1,3 @@
+export interface UserNicknameResponse {
+  nickname: string;
+}

--- a/src/pages/homePage/HomePage.tsx
+++ b/src/pages/homePage/HomePage.tsx
@@ -1,3 +1,4 @@
+import fetchUserNickname from '@apis/user/axios';
 import LookCard from '@components/card/lookCard/LookCard';
 import MapCard from '@components/card/mapCard/MapCard';
 import CurationCarousel from '@components/carousel/curationCarousel/CurationCarousel';
@@ -6,14 +7,24 @@ import PopularCarousel from '@components/carousel/popularCarousel/PopularCarouse
 import DetailTitle from '@components/detailTitle/DetailTitle';
 import Footer from '@components/footer/Footer';
 import Header from '@components/header/Header';
+import { useEffect, useState } from 'react';
 
 import * as styles from './homePage.css';
 
 const HomePage = () => {
+  const [nickname, setNickname] = useState<string>('');
+
+  useEffect(() => {
+    const userId = Number(localStorage.getItem('userId'));
+    if (userId) {
+      fetchUserNickname(userId).then((data) => setNickname(data.nickname));
+    }
+  }, []);
+
   return (
     <div className={styles.homeWrapper}>
       <Header />
-      <LookCard name="절로가" />
+      <LookCard name={nickname} />
       <MapCard />
       <div className={styles.curationCarouselStyle}>
         <DetailTitle title="절로가 PICK!" />

--- a/src/pages/homePage/HomePage.tsx
+++ b/src/pages/homePage/HomePage.tsx
@@ -1,4 +1,4 @@
-import fetchUserNickname from '@apis/user/axios';
+import { fetchUserNickname } from '@apis/user/axios';
 import LookCard from '@components/card/lookCard/LookCard';
 import MapCard from '@components/card/mapCard/MapCard';
 import CurationCarousel from '@components/carousel/curationCarousel/CurationCarousel';

--- a/src/pages/onboardingPage/OnboardingPage.tsx
+++ b/src/pages/onboardingPage/OnboardingPage.tsx
@@ -1,4 +1,6 @@
-import fetchUserNickname from '@apis/user/axios';
+import useRegisterUser from '@apis/user';
+import { fetchUserNickname } from '@apis/user/axios';
+import { OnboardingUserRequest } from '@apis/user/type';
 import ProgressBar from '@components/common/progressBar/ProgressBar';
 import OnboardingSection from '@components/onboarding/OnboardingSection';
 import { ONBOARDING_STEPS, COMMON_DESCRIPTION } from '@constants/onboarding/onboardingSteps';
@@ -21,9 +23,11 @@ const OnboardingPage = () => {
   });
 
   const [userName, setUserName] = useState<string>('');
+  const userId = Number(localStorage.getItem('userId'));
+  const { mutate: registerUserMutate } = useRegisterUser();
 
   useEffect(() => {
-    const userId = Number(localStorage.getItem('userId') || '');
+    const userId = Number(localStorage.getItem('userId'));
     if (userId) {
       fetchUserNickname(userId).then((data) => setUserName(data.nickname));
     }
@@ -48,9 +52,21 @@ const OnboardingPage = () => {
     setSelections((prev) => ({ ...prev, [stepId]: selected }));
   };
 
-  const handleFinalSubmit = () => {
-    localStorage.removeItem('onboardingSelections');
-    nextStep();
+  const handleFinalSubmit = async () => {
+    const requestData: OnboardingUserRequest = {
+      userId,
+      ageRange: selections['ageRange'],
+      gender: selections['gender'],
+      religion: selections['religion'],
+      hasExperience: selections['hasExperience'],
+    };
+
+    registerUserMutate(requestData, {
+      onSuccess: () => {
+        localStorage.removeItem('onboardingSelections');
+        nextStep();
+      },
+    });
   };
 
   return (

--- a/src/pages/onboardingPage/OnboardingPage.tsx
+++ b/src/pages/onboardingPage/OnboardingPage.tsx
@@ -1,3 +1,4 @@
+import fetchUserNickname from '@apis/user/axios';
 import ProgressBar from '@components/common/progressBar/ProgressBar';
 import OnboardingSection from '@components/onboarding/OnboardingSection';
 import { ONBOARDING_STEPS, COMMON_DESCRIPTION } from '@constants/onboarding/onboardingSteps';
@@ -19,7 +20,14 @@ const OnboardingPage = () => {
       : ONBOARDING_STEPS.reduce((acc, step) => ({ ...acc, [step.id]: null }), {});
   });
 
-  const [userName] = useState<string>('');
+  const [userName, setUserName] = useState<string>('');
+
+  useEffect(() => {
+    const userId = Number(localStorage.getItem('userId') || '');
+    if (userId) {
+      fetchUserNickname(userId).then((data) => setUserName(data.nickname));
+    }
+  }, []);
 
   const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true);
   useEffect(() => {

--- a/src/pages/welcomePage/WelcomePage.tsx
+++ b/src/pages/welcomePage/WelcomePage.tsx
@@ -1,4 +1,4 @@
-import fetchUserNickname from '@apis/user/axios';
+import { fetchUserNickname } from '@apis/user/axios';
 import welcomeImg from '@assets/images/img_login_finish.png';
 import PageBottomBtn from '@components/common/button/pageBottomBtn/PageBottomBtn';
 import { WELCOME_TEXT } from '@constants/onboarding/onboardingSteps';

--- a/src/pages/welcomePage/WelcomePage.tsx
+++ b/src/pages/welcomePage/WelcomePage.tsx
@@ -1,14 +1,22 @@
+import fetchUserNickname from '@apis/user/axios';
 import welcomeImg from '@assets/images/img_login_finish.png';
 import PageBottomBtn from '@components/common/button/pageBottomBtn/PageBottomBtn';
 import { WELCOME_TEXT } from '@constants/onboarding/onboardingSteps';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import * as styles from './welcomePage.css';
 
 const WelcomePage = () => {
   const navigate = useNavigate();
-  const [userName] = useState<string>('');
+  const [userName, setUserName] = useState<string>('');
+
+  useEffect(() => {
+    const userId = Number(localStorage.getItem('userId') || '');
+    if (userId) {
+      fetchUserNickname(userId).then((data) => setUserName(data.nickname));
+    }
+  }, []);
 
   const handleStart = () => {
     navigate('/');


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #136 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 사용자 닉네임을 받아서 띄우는 api 연결
  - 홈페이지 LookCard에 닉네임 적용
  - 온보딩 페이지에 닉네임 적용
- 온보딩 마지막 단계 후 로컬스토리지에 저장되어있던 사용자 정보 정송 api 연결

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 간단한 api들이라 React Query 장점이 없는 것 같아 axios로만 할지 고민했지만, 우선은 React Query로 구현하였습니다.
- 수정사항 있으면 말씀해주세요

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->

https://github.com/user-attachments/assets/f428dd77-6219-4bcd-8329-c53a47654a1a

