### PR TITLE
[FIX] 로티 key 추가 및 홈페이지 헤더 아이콘 수정

### DIFF
--- a/src/components/card/lookCard/LookCard.tsx
+++ b/src/components/card/lookCard/LookCard.tsx
@@ -13,6 +13,7 @@ const LookCard = ({ name }: LookCardProps) => {
   return (
     <section className={styles.cardWrapper}>
       <dotlottie-player
+        key="look"
         className={styles.lottieStyle}
         src="src/assets/lotties/home.lottie"
         autoplay

--- a/src/components/common/empty/filterEmpty/FilterEmpty.tsx
+++ b/src/components/common/empty/filterEmpty/FilterEmpty.tsx
@@ -8,7 +8,8 @@ const FilterEmpty = () => {
       <div>
         <p className={styles.textStyle}>{'해당되는 템플스테이를\n찾지 못했어요'}</p>
         <dotlottie-player
-          src="src/assets/lotties/moktak_hit.lottie"
+          key="filter"
+          src="src/assets/lotties/moktak_sad.lottie"
           autoplay
           loop
           style={{ width: '15rem', height: '10.3rem' }}

--- a/src/components/common/empty/searchEmpty/SearchEmpty.tsx
+++ b/src/components/common/empty/searchEmpty/SearchEmpty.tsx
@@ -14,7 +14,8 @@ const SearchEmpty = ({ text }: SearchEmptyProps) => {
           '<span className={styles.highlight}>{`${text}`}</span>'{'에 대한\n검색결과가 없어요'}
         </p>
         <dotlottie-player
-          src="src/assets/lotties/moktak_hit.lottie"
+          key="search"
+          src="src/assets/lotties/moktak_sad.lottie"
           autoplay
           loop
           style={{ width: '15rem', height: '10.3rem' }}

--- a/src/components/except/exceptLayout/ExceptLayout.tsx
+++ b/src/components/except/exceptLayout/ExceptLayout.tsx
@@ -15,7 +15,13 @@ const ExceptLayout = ({ type }: ExceptLayoutProps) => {
     <section className={styles.exceptWrapper}>
       <span className={styles.title}>{title}</span>
       <div className={styles.imgContainer}>
-        <dotlottie-player src={lottie} autoplay loop style={{ width: 210, height: 210 }} />
+        <dotlottie-player
+          key={type}
+          src={lottie}
+          autoplay
+          loop
+          style={{ width: 210, height: 210 }}
+        />
       </div>
       <span className={styles.subtitle[type]}>{subtitle}</span>
     </section>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -4,20 +4,21 @@ import useNavigateTo from '@hooks/useNavigateTo';
 import * as styles from './header.css';
 
 const Header = () => {
-  const handleClick = () => {};
   const navigateToWishList = useNavigateTo('/wishList');
   const navigateToMyPage = useNavigateTo('/myPage');
 
   return (
     <header className={styles.headerContainer}>
-      <button onClick={handleClick}>
+      <button onClick={useNavigateTo('/')}>
         <Icon.SmallLogo />
       </button>
       <nav className={styles.iconBox}>
         <Icon.IcnSearchLargeBlack className={styles.iconStyle} onClick={useNavigateTo('/search')} />
-        <Icon.IcnSearchLargeBlack className={styles.iconStyle} onClick={() => handleClick()} />
-        <Icon.IcnWish className={styles.iconStyle} onClick={navigateToWishList} />
         <Icon.IcnMyPage className={styles.iconStyle} onClick={navigateToMyPage} />
+        <Icon.IcnFlowerPink
+          className={`${styles.iconStyle} ${styles.flowerPinkStyle}`}
+          onClick={navigateToWishList}
+        />
       </nav>
     </header>
   );

--- a/src/components/header/header.css.ts
+++ b/src/components/header/header.css.ts
@@ -22,3 +22,8 @@ export const iconBox = style({
 export const iconStyle = style({
   cursor: 'pointer',
 });
+
+export const flowerPinkStyle = style({
+  width: '2.8rem',
+  height: '2.8rem',
+});

--- a/src/pages/loginPage/LoginPage.tsx
+++ b/src/pages/loginPage/LoginPage.tsx
@@ -22,6 +22,7 @@ const LoginPage = () => {
         <h2 className={styles.textStyle}>{text}</h2>
 
         <dotlottie-player
+          key={type}
           src={lottie}
           autoplay
           loop

--- a/src/pages/welcomePage/WelcomePage.tsx
+++ b/src/pages/welcomePage/WelcomePage.tsx
@@ -24,7 +24,12 @@ const WelcomePage = () => {
     <div className={styles.container}>
       <h1 className={styles.titleStyle}>{`${userName}${WELCOME_TEXT}`}</h1>
       <div className={styles.lottieStyle}>
-        <dotlottie-player src="src/assets/lotties/onboarding.lottie" autoplay loop />
+        <dotlottie-player
+          key="onboarding"
+          src="src/assets/lotties/onboarding.lottie"
+          autoplay
+          loop
+        />
       </div>
       <PageBottomBtn btnText="절로가 시작하기" size="large" onClick={handleStart} />
     </div>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #166 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 로티가 상황에 맞게 변경되지 않고 하나만 뜨는 문제를 해결하기 위해 key값 추가했습니다.
- 홈페이지 헤더 검색 아이콘 하나 삭제
- 헤더 로고 클릭 시 홈페이지 이동 추가
- 홈페이지 헤더 위시 아이콘 변경 및 위치 수정

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->