### PR TITLE
[FEAT] 첫 로그인한 유저인 경우 온보딩 페이지로 이동 로직 구현

### DIFF
--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -11,14 +11,14 @@ export const useGetKakaoLogin = () => {
       const userId = response.data.userId;
       const accessToken = response.headers['authorization'].replace('Bearer ', '');
       const refreshToken = response.headers['refreshtoken'];
+      const userNickname = response.data.nickname;
 
-      if (userId) {
-        localStorage.setItem('userId', userId);
-        localStorage.setItem('Authorization', accessToken);
-        localStorage.setItem('refreshToken', refreshToken);
+      localStorage.setItem('userId', userId);
+      localStorage.setItem('Authorization', accessToken);
+      localStorage.setItem('refreshToken', refreshToken);
 
-        navigate('/');
-      }
+      if (!userNickname) navigate('/onboarding');
+      else navigate('/');
     },
     onError: (error) => {
       console.error(error);
@@ -32,8 +32,8 @@ export const usePostLogout = () => {
   return useMutation({
     mutationFn: () => postLogout(),
     onSuccess: () => {
-      localStorage.removeItem('Authorization');
       navigate('/');
+      localStorage.clear();
     },
 
     onError: (error) => {

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -20,8 +20,8 @@ export const useGetKakaoLogin = () => {
 
       if (!userNickname) {
         navigate('/onboarding');
-      }
-      else navigate('/');
+      } else {
+        navigate('/');
       }
     },
     onError: (error) => {

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -51,7 +51,7 @@ privateInstance.interceptors.response.use(
       response: { status },
     } = error;
 
-    if (status === 401) {
+    if (status === 500) {
       try {
         const response = await postRefreshToken();
 

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 
-import { getMyPage, registerUser } from './axios';
+import { fetchUserNickname, getMyPage, registerUser } from './axios';
 import { MyPageType, OnboardingUserRequest } from './type';
 
 export const useRegisterUser = () => {
@@ -13,6 +13,15 @@ export const useGetMyPage = (userId: string) => {
   const { data, isLoading, isError } = useQuery<MyPageType>({
     queryKey: ['myPage', userId],
     queryFn: () => getMyPage(userId),
+  });
+
+  return { data, isLoading, isError };
+};
+
+export const useGetNickname = (userId: number) => {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: [userId],
+    queryFn: () => fetchUserNickname(userId),
   });
 
   return { data, isLoading, isError };

--- a/src/components/card/lookCard/LookCard.tsx
+++ b/src/components/card/lookCard/LookCard.tsx
@@ -4,10 +4,10 @@ import useFilter from '@hooks/useFilter';
 import * as styles from './lookCard.css';
 
 interface LookCardProps {
-  name: string;
+  name?: string;
 }
 
-const LookCard = ({ name }: LookCardProps) => {
+const LookCard = ({ name = '일로가' }: LookCardProps) => {
   const { handleSearch } = useFilter();
 
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,7 +15,9 @@ import queryClient from './queryClient.ts';
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <ReactQueryDevtools initialIsOpen={false} />
+      <div style={{ fontSize: '16px' }}>
+        <ReactQueryDevtools initialIsOpen={false} />
+      </div>
       <Provider>
         <Router />
       </Provider>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,0 @@
-const HomePage = () => {
-  return <div>HomePage</div>;
-};
-
-export default HomePage;

--- a/src/pages/homePage/HomePage.tsx
+++ b/src/pages/homePage/HomePage.tsx
@@ -1,38 +1,40 @@
-import { fetchUserNickname } from '@apis/user/axios';
+import { useGetNickname } from '@apis/user';
 import LookCard from '@components/card/lookCard/LookCard';
 import MapCard from '@components/card/mapCard/MapCard';
 import CurationCarousel from '@components/carousel/curationCarousel/CurationCarousel';
 import PopularCarousel from '@components/carousel/popularCarousel/PopularCarousel';
 import DetailTitle from '@components/detailTitle/DetailTitle';
+import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import Footer from '@components/footer/Footer';
 import Header from '@components/header/Header';
 import useFilter from '@hooks/useFilter';
 import { useSetAtom } from 'jotai';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { contentAtom } from 'src/store/store';
 
 import * as styles from './homePage.css';
 
 const HomePage = () => {
   const { handleResetFilter } = useFilter();
-  const [nickname, setNickname] = useState<string>('');
   const setContent = useSetAtom(contentAtom);
 
   useEffect(() => {
     setContent('');
     handleResetFilter();
     localStorage.setItem('prevPage', '/');
-
-    const userId = Number(localStorage.getItem('userId'));
-    if (userId) {
-      fetchUserNickname(userId).then((data) => setNickname(data.nickname));
-    }
   }, []);
+
+  const userId = Number(localStorage.getItem('userId'));
+  const { data, isLoading } = useGetNickname(userId);
+
+  if (isLoading) {
+    return <ExceptLayout type="loading" />;
+  }
 
   return (
     <div className={styles.homeWrapper}>
       <Header />
-      <LookCard name={nickname} />
+      <LookCard name={data?.nickname} />
       <MapCard />
       <div className={styles.curationCarouselStyle}>
         <DetailTitle title="절로가 PICK!" />

--- a/src/pages/onboardingPage/OnboardingPage.tsx
+++ b/src/pages/onboardingPage/OnboardingPage.tsx
@@ -1,7 +1,7 @@
-import { useRegisterUser } from '@apis/user';
-import { fetchUserNickname } from '@apis/user/axios';
+import { useGetNickname, useRegisterUser } from '@apis/user';
 import { OnboardingUserRequest } from '@apis/user/type';
 import ProgressBar from '@components/common/progressBar/ProgressBar';
+import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import OnboardingSection from '@components/onboarding/OnboardingSection';
 import { ONBOARDING_STEPS, COMMON_DESCRIPTION } from '@constants/onboarding/onboardingSteps';
 import useFunnel from '@hooks/useFunnel';
@@ -22,17 +22,10 @@ const OnboardingPage = () => {
       : ONBOARDING_STEPS.reduce((acc, step) => ({ ...acc, [step.id]: null }), {});
   });
 
-  const [userName, setUserName] = useState<string>('');
   const userId = Number(localStorage.getItem('userId'));
   const { mutate: registerUserMutate } = useRegisterUser();
 
-  useEffect(() => {
-    const userId = Number(localStorage.getItem('userId'));
-    if (userId) {
-      fetchUserNickname(userId).then((data) => setUserName(data.nickname));
-    }
-  }, []);
-
+  const { data, isLoading } = useGetNickname(userId);
   const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true);
   useEffect(() => {
     if (isInitialLoad) {
@@ -69,6 +62,10 @@ const OnboardingPage = () => {
     });
   };
 
+  if (isLoading) {
+    return <ExceptLayout type="loading" />;
+  }
+
   return (
     <div className={container}>
       <ProgressBar
@@ -82,7 +79,9 @@ const OnboardingPage = () => {
             <Step key={id} name={id}>
               <OnboardingSection
                 id={id}
-                title={id === 'ageRange' || id === 'gender' ? [`${userName}님의`, title] : title}
+                title={
+                  id === 'ageRange' || id === 'gender' ? [`${data?.nickname}님의`, title] : title
+                }
                 description={COMMON_DESCRIPTION}
                 options={options}
                 isNextDisabledInitially={isNextDisabledInitially || false}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #172

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 처음 로그인 하는 유저 온보딩 페이지로 이동
- 닉네임 가져오는 api useQuery로 로딩 붙여서 데이터 받아와야 이름 보이도록 설정

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->