### PR TITLE
[FEAT] 비로그인 위시 클릭 시 로그인 연결

### DIFF
--- a/src/components/card/popularCard/PopularCard.tsx
+++ b/src/components/card/popularCard/PopularCard.tsx
@@ -29,6 +29,13 @@ const PopularCard = ({
 
   const handleLikeClick = (e: React.MouseEvent) => {
     e.stopPropagation();
+
+    const userId = Number(localStorage.getItem('userId'));
+    if (!userId) {
+      onLikeToggle(liked);
+      return;
+    }
+
     setLiked((prev) => !prev);
     onLikeToggle(liked);
   };

--- a/src/components/card/templeStayCard/TempleStayCard.tsx
+++ b/src/components/card/templeStayCard/TempleStayCard.tsx
@@ -16,6 +16,7 @@ interface TempleStayCardProps {
   layout: 'vertical' | 'horizontal';
   onToggleWishlist: (templestayId: number, liked: boolean) => void;
   onClick?: () => void;
+  onRequireLogin?: () => void;
 }
 
 const TempleStayCard = ({
@@ -30,12 +31,20 @@ const TempleStayCard = ({
   layout,
   onToggleWishlist,
   onClick,
+  onRequireLogin,
 }: TempleStayCardProps) => {
   const [isWished, setIsWished] = useState(liked);
   const isHorizontal = layout === 'horizontal';
 
   const onClickWishBtn = (e: React.MouseEvent) => {
     e.stopPropagation();
+
+    const userId = Number(localStorage.getItem('userId'));
+    if (!userId) {
+      onRequireLogin?.();
+      return;
+    }
+
     setIsWished((prev) => !prev);
     onToggleWishlist(templestayId, isWished);
   };

--- a/src/components/card/templeStayCard/searchCardList/SearchCardList.tsx
+++ b/src/components/card/templeStayCard/searchCardList/SearchCardList.tsx
@@ -17,9 +17,15 @@ interface SearchCardListProps {
   }[];
   layout: 'vertical' | 'horizontal';
   onToggleWishlist: (templestayId: number, liked: boolean) => void;
+  onRequireLogin?: () => void;
 }
 
-const SearchCardList = ({ data, layout = 'horizontal', onToggleWishlist }: SearchCardListProps) => {
+const SearchCardList = ({
+  data,
+  layout = 'horizontal',
+  onToggleWishlist,
+  onRequireLogin,
+}: SearchCardListProps) => {
   const navigate = useNavigate();
 
   const handleCardClick = (templestayId: number) => {
@@ -42,6 +48,7 @@ const SearchCardList = ({ data, layout = 'horizontal', onToggleWishlist }: Searc
           layout={layout}
           onToggleWishlist={onToggleWishlist}
           onClick={() => handleCardClick(temple.templestayId)}
+          onRequireLogin={onRequireLogin}
         />
       ))}
     </section>

--- a/src/components/carousel/popularCarousel/PopularCarousel.tsx
+++ b/src/components/carousel/popularCarousel/PopularCarousel.tsx
@@ -2,6 +2,7 @@ import useGetRanking from '@apis/ranking';
 import { useAddWishlist, useRemoveWishlist } from '@apis/wish';
 import PopularCard from '@components/card/popularCard/PopularCard';
 import CarouselIndex from '@components/carousel/popularCarousel/CarouselIndex';
+import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import useCarousel from '@hooks/useCarousel';
 import { useQueryClient } from '@tanstack/react-query';
 import registDragEvent from '@utils/registDragEvent';
@@ -10,7 +11,11 @@ import { useNavigate } from 'react-router-dom';
 
 import * as styles from './popularCarousel.css';
 
-const PopularCarousel = () => {
+interface PopularCarouselProps {
+  onRequireLogin: () => void;
+}
+
+const PopularCarousel = ({ onRequireLogin }: PopularCarouselProps) => {
   const userId = Number(localStorage.getItem('userId'));
   const queryClient = useQueryClient();
 
@@ -28,16 +33,20 @@ const PopularCarousel = () => {
   const navigate = useNavigate();
 
   if (isLoading) {
-    return <p>Loading...</p>;
+    return <ExceptLayout type="loading" />;
   }
 
   if (isError) {
-    return <p>Error</p>;
+    return <ExceptLayout type="networkError" />;
   }
 
   const handleLikeToggle = (templestayId: number, liked: boolean) => {
-    const mutation = liked ? removeWishlistMutation : addWishlistMutation;
+    if (!userId) {
+      onRequireLogin();
+      return;
+    }
 
+    const mutation = liked ? removeWishlistMutation : addWishlistMutation;
     mutation.mutate(
       { userId, templestayId },
       {

--- a/src/components/common/button/buttonBar/buttonBar.css.ts
+++ b/src/components/common/button/buttonBar/buttonBar.css.ts
@@ -6,7 +6,7 @@ const buttonBarContainer = style({
   bottom: 0,
   left: '50%',
   transform: 'translateX(-50%)',
-  zIndex: 999,
+  zIndex: 1,
 
   display: 'flex',
   alignItems: 'center',

--- a/src/components/common/modal/modal.css.ts
+++ b/src/components/common/modal/modal.css.ts
@@ -7,6 +7,9 @@ export const modalContainer = style({
   alignItems: 'center',
   gap: '2.8rem',
   position: 'fixed',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
 
   width: '33.1rem',
   height: '18.1rem',
@@ -21,10 +24,13 @@ export const modalBackdrop = style({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
+  position: 'absolute',
+  top: 0,
+  left: 0,
 
   zIndex: 3,
   width: '100%',
-  height: '100vh',
+  height: 'calc(100% + 1.2rem)',
   background: theme.COLORS.black60,
 
   marginTop: '-1.2rem',

--- a/src/components/common/pageName/PageName.tsx
+++ b/src/components/common/pageName/PageName.tsx
@@ -10,7 +10,7 @@ interface PageNameProps {
   isLiked?: boolean;
 }
 
-const PageName = ({ title, onRightClick, isLikeBtn = true, isLiked = false }: PageNameProps) => {
+const PageName = ({ title, onRightClick, isLikeBtn = true, isLiked = true }: PageNameProps) => {
   const handleToBack = useNavigateTo('/');
 
   return (

--- a/src/components/templeDetail/templeTopbar/TempleTopbar.tsx
+++ b/src/components/templeDetail/templeTopbar/TempleTopbar.tsx
@@ -14,7 +14,7 @@ const TempleTopbar = ({ templeName, templestayName }: TempleTopbarProps) => {
       <PageName
         title={`${templeName} ${templestayName}`}
         onRightClick={navigateToWishlist}
-        isLikeBtn={true}
+        isLikeBtn={false}
       />
     </div>
   );

--- a/src/components/templeDetail/templeTopbar/TempleTopbar.tsx
+++ b/src/components/templeDetail/templeTopbar/TempleTopbar.tsx
@@ -1,25 +1,20 @@
 import PageName from '@components/common/pageName/PageName';
+import useNavigateTo from '@hooks/useNavigateTo';
 
 interface TempleTopbarProps {
   templeName: string;
   templestayName: string;
-  liked: boolean;
-  onToggleWishlist: () => void;
 }
 
-const TempleTopbar = ({
-  templeName,
-  templestayName,
-  liked,
-  onToggleWishlist,
-}: TempleTopbarProps) => {
+const TempleTopbar = ({ templeName, templestayName }: TempleTopbarProps) => {
+  const navigateToWishlist = useNavigateTo('/wishList');
+
   return (
     <div>
       <PageName
         title={`${templeName} ${templestayName}`}
-        onRightClick={onToggleWishlist}
+        onRightClick={navigateToWishlist}
         isLikeBtn={true}
-        isLiked={liked}
       />
     </div>
   );

--- a/src/pages/homePage/HomePage.tsx
+++ b/src/pages/homePage/HomePage.tsx
@@ -3,6 +3,7 @@ import LookCard from '@components/card/lookCard/LookCard';
 import MapCard from '@components/card/mapCard/MapCard';
 import CurationCarousel from '@components/carousel/curationCarousel/CurationCarousel';
 import PopularCarousel from '@components/carousel/popularCarousel/PopularCarousel';
+import ModalContainer from '@components/common/modal/ModalContainer';
 import DetailTitle from '@components/detailTitle/DetailTitle';
 import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import Footer from '@components/footer/Footer';
@@ -17,6 +18,19 @@ import * as styles from './homePage.css';
 const HomePage = () => {
   const { handleResetFilter } = useFilter();
   const setContent = useSetAtom(contentAtom);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleLoginRedirect = () => {
+    window.location.href = '/login';
+  };
+
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
 
   useEffect(() => {
     setContent('');
@@ -33,6 +47,20 @@ const HomePage = () => {
 
   return (
     <div className={styles.homeWrapper}>
+      {isModalOpen && (
+        <div className={styles.modalOverlay}>
+          <ModalContainer
+            modalTitle="로그인 하시겠어요?"
+            modalBody="찜하려면 로그인이 필요해요."
+            isOpen={isModalOpen}
+            handleClose={closeModal}
+            handleSubmit={handleLoginRedirect}
+            leftBtnLabel="취소"
+            rightBtnLabel="로그인하기"
+          />
+        </div>
+      )}
+
       <Header />
       <LookCard name={data?.nickname} />
       <MapCard />
@@ -42,7 +70,7 @@ const HomePage = () => {
       </div>
       <div className={styles.popularCarouselStyle}>
         <DetailTitle title="이번 주 인기 템플스테이" />
-        <PopularCarousel />
+        <PopularCarousel onRequireLogin={openModal} />
       </div>
       <Footer />
     </div>

--- a/src/pages/homePage/HomePage.tsx
+++ b/src/pages/homePage/HomePage.tsx
@@ -10,7 +10,7 @@ import Footer from '@components/footer/Footer';
 import Header from '@components/header/Header';
 import useFilter from '@hooks/useFilter';
 import { useSetAtom } from 'jotai';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { contentAtom } from 'src/store/store';
 
 import * as styles from './homePage.css';

--- a/src/pages/homePage/homePage.css.ts
+++ b/src/pages/homePage/homePage.css.ts
@@ -1,3 +1,4 @@
+import theme from '@styles/theme.css';
 import { style } from '@vanilla-extract/css';
 
 const flexCenterColumn = style({
@@ -6,6 +7,7 @@ const flexCenterColumn = style({
   alignItems: 'center',
   justifyContent: 'center',
   touchAction: 'none',
+  position: 'relative',
 });
 
 export const homeWrapper = flexCenterColumn;
@@ -27,12 +29,13 @@ export const popularCarouselStyle = style([
 ]);
 
 export const modalOverlay = style({
-  position: 'fixed',
+  position: 'absolute',
   top: 0,
   left: 0,
   width: '100%',
-  height: '100%',
-  backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  height: 'calc(100% + 1.2rem)',
+  marginTop: '-1.2rem',
+  backgroundColor: theme.COLORS.black60,
   justifyContent: 'center',
   alignItems: 'center',
   zIndex: 1,

--- a/src/pages/homePage/homePage.css.ts
+++ b/src/pages/homePage/homePage.css.ts
@@ -25,3 +25,15 @@ export const popularCarouselStyle = style([
     margin: '5.4rem 0 28rem 0',
   },
 ]);
+
+export const modalOverlay = style({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  justifyContent: 'center',
+  alignItems: 'center',
+  zIndex: 1,
+});

--- a/src/pages/loginPage/LoginPage.tsx
+++ b/src/pages/loginPage/LoginPage.tsx
@@ -11,7 +11,7 @@ type LoginType = 'my' | 'wish';
 const LoginPage = () => {
   const location = useLocation();
 
-  const type: LoginType = location.state?.type || 'my';
+  const type: LoginType = location.state?.type || 'wish';
 
   const { title, text, lottie } = LOGIN_INFOS[type];
 

--- a/src/pages/searchResultPage/SearchResultPage.tsx
+++ b/src/pages/searchResultPage/SearchResultPage.tsx
@@ -1,6 +1,7 @@
 import { useAddWishlist, useRemoveWishlist } from '@apis/wish';
 import SearchCardList from '@components/card/templeStayCard/searchCardList/SearchCardList';
 import SearchEmpty from '@components/common/empty/searchEmpty/SearchEmpty';
+import ModalContainer from '@components/common/modal/ModalContainer';
 import Pagination from '@components/common/pagination/Pagination';
 import FilterTypeBox from '@components/filter/filterTypeBox/FilterTypeBox';
 import SearchHeader from '@components/search/searchHeader/SearchHeader';
@@ -30,10 +31,14 @@ const SearchResultPage = () => {
     }
   }, [results, content]);
 
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [currentPage, setCurrentPage] = useState(results.page);
   const [templestays, setTemplestays] = useState(results.templestays);
   const [searchText, setSearchText] = useState(content);
   const { handleSearch } = useFilter();
+
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -65,6 +70,18 @@ const SearchResultPage = () => {
 
   return (
     <div className={styles.container}>
+      {isModalOpen && (
+        <ModalContainer
+          modalTitle="로그인 하시겠어요?"
+          modalBody="찜하려면 로그인이 필요해요."
+          isOpen={isModalOpen}
+          handleClose={closeModal}
+          handleSubmit={() => (window.location.href = '/login')}
+          leftBtnLabel="취소"
+          rightBtnLabel="로그인하기"
+        />
+      )}
+
       <div className={styles.headerContainer}>
         <SearchHeader searchText={searchText} prevPath={prevPath} />
         <FilterTypeBox activeFilters={activeFilters} />
@@ -77,6 +94,7 @@ const SearchResultPage = () => {
             data={templestays}
             layout="horizontal"
             onToggleWishlist={handleToggleWishlist}
+            onRequireLogin={openModal}
           />
           <Pagination
             currentPage={currentPage}

--- a/src/pages/searchResultPage/searchResultPage.css.ts
+++ b/src/pages/searchResultPage/searchResultPage.css.ts
@@ -4,6 +4,7 @@ import { style } from '@vanilla-extract/css';
 export const container = style({
   minHeight: '100vh',
   backgroundColor: theme.COLORS.gray1,
+  position: 'relative',
 });
 
 export const headerContainer = style({

--- a/src/pages/templeDetailPage/TempleDetailPage.tsx
+++ b/src/pages/templeDetailPage/TempleDetailPage.tsx
@@ -2,6 +2,7 @@ import useGetTempleDetails from '@apis/templeDetail';
 import { useAddWishlist, useRemoveWishlist } from '@apis/wish';
 import DetailCarousel from '@components/carousel/detailCarousel/DetailCarousel';
 import ButtonBar from '@components/common/button/buttonBar/ButtonBar';
+import ModalContainer from '@components/common/modal/ModalContainer';
 import TapBar from '@components/common/tapBar/TapBar';
 import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import SmallMap from '@components/templeDetail/naverMap/smallMap/SmallMap';
@@ -36,6 +37,7 @@ const TempleDetailPage = () => {
   const removeWishlistMutation = useRemoveWishlist();
 
   const [liked, setLiked] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   useEffect(() => {
     if (data) {
       setLiked(data.liked);
@@ -43,6 +45,11 @@ const TempleDetailPage = () => {
   }, [data]);
 
   const handleToggleWishlist = () => {
+    if (!userId) {
+      setIsModalOpen(true);
+      return;
+    }
+
     const mutation = liked ? removeWishlistMutation : addWishlistMutation;
 
     mutation.mutate(
@@ -56,6 +63,8 @@ const TempleDetailPage = () => {
       },
     );
   };
+
+  const closeModal = () => setIsModalOpen(false);
 
   if (isLoading) {
     return <ExceptLayout type="loading" />;
@@ -75,6 +84,18 @@ const TempleDetailPage = () => {
 
   return (
     <div className={styles.templeDetailWrapper}>
+      {isModalOpen && (
+        <ModalContainer
+          modalTitle="로그인 하시겠어요?"
+          modalBody="찜하려면 로그인이 필요해요."
+          isOpen={isModalOpen}
+          handleClose={closeModal}
+          handleSubmit={() => (window.location.href = '/login')}
+          leftBtnLabel="취소"
+          rightBtnLabel="로그인하기"
+        />
+      )}
+
       <div className={styles.headerBox}>
         <TempleTopbar templeName={data.templeName} templestayName={data.templestayName} />
       </div>

--- a/src/pages/templeDetailPage/TempleDetailPage.tsx
+++ b/src/pages/templeDetailPage/TempleDetailPage.tsx
@@ -76,12 +76,7 @@ const TempleDetailPage = () => {
   return (
     <div className={styles.templeDetailWrapper}>
       <div className={styles.headerBox}>
-        <TempleTopbar
-          templeName={data.templeName}
-          templestayName={data.templestayName}
-          liked={liked}
-          onToggleWishlist={handleToggleWishlist}
-        />
+        <TempleTopbar templeName={data.templeName} templestayName={data.templestayName} />
       </div>
       <div className={styles.topDetailContainer}>
         <DetailCarousel />

--- a/src/stories/PopularCarousel.stories.ts
+++ b/src/stories/PopularCarousel.stories.ts
@@ -14,4 +14,8 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    onRequireLogin: () => alert('로그인이 필요합니다.'),
+  },
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #194 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 로그인하지 않은 사용자가 찜하기 버튼을 누르면 모달창이 뜨도록 모든 곳을 연결했습니다.
- 모달의 백드롭이 웹 전체화면에 떠서 화면에 맞게 조정하였습니다.
- 모달창에서 로그인하기 버튼을 누르면 현재는 위시리스트를 누를때와 동일한 로그인 연결 페이지가 뜹니다.
- 상세페이지에서 상단 헤더의 위시 아이콘은 찜하기 기능이 아니라 위시리스트로 연결되도록 수정하였습니다.

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 수정사항 있으면 말씀해주세요.

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->