### PR TITLE
[FIX] 큐레이션 탑바 상단 고정, 캐러셀 감도 조절

### DIFF
--- a/src/hooks/useCarousel.ts
+++ b/src/hooks/useCarousel.ts
@@ -17,10 +17,10 @@ const useCarousel = ({ itemCount, moveDistance }: UseCarouselProps) => {
   const handleDragEnd = (deltaX: number) => {
     const maxIndex = itemCount - 1;
 
-    if (deltaX < -100) {
+    if (deltaX < -50) {
       // 왼쪽으로 드래그
       setCurrentIndex(currentIndex + 1 > maxIndex ? maxIndex : currentIndex + 1);
-    } else if (deltaX > 100) {
+    } else if (deltaX > 50) {
       // 오른쪽으로 드래그
       setCurrentIndex(currentIndex - 1 < 0 ? 0 : currentIndex - 1);
     }

--- a/src/pages/CurationPage/CurationPage.tsx
+++ b/src/pages/CurationPage/CurationPage.tsx
@@ -2,6 +2,8 @@ import PageName from '@components/common/pageName/PageName';
 import { CURATION_IMAGES } from '@constants/curationInfo';
 import { useParams } from 'react-router-dom';
 
+import { headerBox, contentBox } from './curationPage.css';
+
 const CurationPage = () => {
   const { index } = useParams();
   const indexNum = parseInt(index || '0');
@@ -10,8 +12,10 @@ const CurationPage = () => {
 
   return (
     <section>
-      <PageName title="큐레이션" isLikeBtn={false} />
-      <div>
+      <div className={headerBox}>
+        <PageName title="큐레이션" isLikeBtn={false} />
+      </div>
+      <div className={contentBox}>
         {images.map((image, idx) => (
           <img key={idx} src={image} alt="큐레이션 이미지" />
         ))}

--- a/src/pages/CurationPage/curationPage.css.ts
+++ b/src/pages/CurationPage/curationPage.css.ts
@@ -1,0 +1,19 @@
+import theme from '@styles/theme.css';
+import { style } from '@vanilla-extract/css';
+
+export const headerBox = style({
+  position: 'fixed',
+  top: 0,
+  width: '37.5rem',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  paddingTop: '1rem',
+  marginBottom: '1rem',
+  zIndex: 2,
+  backgroundColor: theme.COLORS.white,
+});
+
+export const contentBox = style({
+  paddingTop: '4.8rem',
+});

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -19,7 +19,7 @@ const DetailPage = lazy(() => import('@pages/templeDetailPage/TempleDetailPage')
 const LargeMap = lazy(() => import('@components/templeDetail/naverMap/largeMap/LargeMap'));
 const DetailPhoto = lazy(() => import('@pages/templeDetailPage/templePhoto/TemplePhotoPage'));
 const DetailBlog = lazy(() => import('@pages/templeDetailPage/blogReview/BlogReviewPage'));
-const CurationPage = lazy(() => import('@pages/CurationPage'));
+const CurationPage = lazy(() => import('@pages/CurationPage/CurationPage'));
 
 const router = createBrowserRouter([
   {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #196 
## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 캐러셀 감도 50으로 줄였습니다.
- 큐레이션 탑바 상단 고정시켰습니다.

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->