### PR TITLE
[FIX] 상세페이지 2차 

### DIFF
--- a/src/components/carousel/curationCarousel/CurationCarousel.tsx
+++ b/src/components/carousel/curationCarousel/CurationCarousel.tsx
@@ -17,6 +17,7 @@ const CurationCarousel = () => {
 
   const handleClick = (index: number) => {
     navigate(`/curation/${index + 1}`);
+    window.scrollTo(0, 0);
   };
 
   return (

--- a/src/components/carousel/detailCarousel/DetailCarousel.tsx
+++ b/src/components/carousel/detailCarousel/DetailCarousel.tsx
@@ -1,4 +1,5 @@
 import useGetTempleImages from '@apis/templeImages';
+import LargeEmptyImage from '@assets/images/img_gray_light_leaf_large.png';
 import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import useCarousel from '@hooks/useCarousel';
 import registDragEvent from '@utils/registDragEvent';
@@ -25,7 +26,11 @@ const DetailCarousel = () => {
   }
 
   if (!data) {
-    return <p>No user information available</p>;
+    return (
+      <div className={styles.emptyImageContainer}>
+        <img src={LargeEmptyImage} alt="빈 이미지"></img>
+      </div>
+    );
   }
 
   return (

--- a/src/components/carousel/detailCarousel/DetailImage.tsx
+++ b/src/components/carousel/detailCarousel/DetailImage.tsx
@@ -1,4 +1,3 @@
-import LargeEmptyImage from '@assets/images/img_gray_light_leaf_large.png';
 import useNavigateTo from '@hooks/useNavigateTo';
 import { useParams } from 'react-router-dom';
 
@@ -16,7 +15,7 @@ const ImageItem = ({ id, imgUrl, currentNum, totalNum }: ImageItemProps) => {
   const { templestayId } = useParams();
 
   const navigateToPhoto = useNavigateTo(`/detail/${templestayId}/photo`);
-  return totalNum ? (
+  return (
     <div
       role="button"
       tabIndex={0}
@@ -32,10 +31,6 @@ const ImageItem = ({ id, imgUrl, currentNum, totalNum }: ImageItemProps) => {
       <div className={styles.numberStyle}>
         <NumberTag currentNum={currentNum} totalNum={totalNum} />
       </div>
-    </div>
-  ) : (
-    <div className={styles.emptyImageContainer}>
-      <img src={LargeEmptyImage} alt="빈 이미지"></img>
     </div>
   );
 };

--- a/src/components/common/detailInfo/detailInfo.css.ts
+++ b/src/components/common/detailInfo/detailInfo.css.ts
@@ -22,4 +22,5 @@ export const content = style({
   whiteSpace: 'nowrap',
   wordBreak: 'break-all',
   overflow: 'hidden',
+  width: '27.4rem',
 });

--- a/src/components/common/tapBar/TapBar.tsx
+++ b/src/components/common/tapBar/TapBar.tsx
@@ -21,7 +21,7 @@ const TapBar = ({ type, selectedTap }: TapBarProps) => {
       : TAPS.detail.map((_, index) => `detail-section-${index}`);
 
   const { scrollIndex, handleClick } = useScrollTracker(sectionIds, headerHeight);
-  const scrollToElement = useMoveScroll(headerHeight);
+  const scrollToElement = useMoveScroll(type, headerHeight);
 
   const handleTabClick = (index: number) => {
     handleClick(index);
@@ -39,7 +39,7 @@ const TapBar = ({ type, selectedTap }: TapBarProps) => {
   }, []);
 
   return (
-    <div className={tapBarContainer}>
+    <div className={tapBarContainer} id="detail-section-0">
       {taplist.map((label, index) => (
         <UnderlinedBtn
           key={index}

--- a/src/components/filter/filterTypeBox/filterTypeBox.css.ts
+++ b/src/components/filter/filterTypeBox/filterTypeBox.css.ts
@@ -6,6 +6,7 @@ export const container = style({
   padding: '1.1rem 2rem',
   height: '5.8rem',
   marginTop: '0.8rem',
+  width: '100%',
 });
 
 export const scrollContainer = style({

--- a/src/components/templeDetail/naverMap/smallMap/SmallMap.tsx
+++ b/src/components/templeDetail/naverMap/smallMap/SmallMap.tsx
@@ -25,7 +25,7 @@ const SmallMap = ({ detailAddress, latitude, longitude }: MapDataProps) => {
   );
 
   return (
-    <div className={styles.mapContainerWrapper} id="detail-section-4">
+    <div className={styles.mapContainerWrapper}>
       <DetailTitle title="지도" />
       <div className={styles.mapContainerStyle}>
         <div className={styles.addressDetailStyle}>

--- a/src/components/templeDetail/stickyTapBar/StickyTapBar.tsx
+++ b/src/components/templeDetail/stickyTapBar/StickyTapBar.tsx
@@ -7,9 +7,9 @@ interface StickyTapBarProps {
 }
 
 const StickyTapBar = ({ children }: StickyTapBarProps) => {
-  const tapBarRef = useRef<HTMLDivElement>(null);
   const [isSticky, setIsSticky] = useState(false);
   const [initialOffsetTop, setInitialOffsetTop] = useState<number | null>(null);
+  const tapBarRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const timeoutId = setTimeout(() => {

--- a/src/components/templeDetail/templeInfo/templeInfo.tsx
+++ b/src/components/templeDetail/templeInfo/templeInfo.tsx
@@ -22,7 +22,7 @@ const TempleInfo = ({ introduction }: TempleInfoProps) => {
   }
 
   return (
-    <div className={styles.templeInfoContainer} id="detail-section-3">
+    <div className={styles.templeInfoContainer} id="detail-section-4">
       <DetailTitle title="템플스테이 정보" />
       {parsedIntroduction ? (
         <div className={styles.templeInfoBoxStyle}>

--- a/src/components/templeDetail/templePrice/TemplePrice.tsx
+++ b/src/components/templeDetail/templePrice/TemplePrice.tsx
@@ -7,7 +7,7 @@ interface TemplePriceProps {
 
 const TemplePrice = ({ templestayPrice }: TemplePriceProps) => {
   return (
-    <div className={styles.templePriceWrapper} id="detail-section-2">
+    <div className={styles.templePriceWrapper} id="detail-section-3">
       <DetailTitle title="가격" />
       {templestayPrice ? (
         <div className={styles.templePriceBox}>

--- a/src/components/templeDetail/templeReview/TempleReview.tsx
+++ b/src/components/templeDetail/templeReview/TempleReview.tsx
@@ -31,7 +31,7 @@ const TempleReview = () => {
   }
 
   return (
-    <div className={styles.templeReviewWrapper} id="detail-section-0">
+    <div className={styles.templeReviewWrapper} id="detail-section-1">
       <DetailTitle
         title="리뷰"
         isTotal={true}

--- a/src/components/templeDetail/templeSchedule/TempleSchedule.tsx
+++ b/src/components/templeDetail/templeSchedule/TempleSchedule.tsx
@@ -20,7 +20,7 @@ const TempleSchedule = ({ schedule }: TempleScheduleProps) => {
   }
 
   return (
-    <div className={styles.templeScheduleContainer} id="detail-section-1">
+    <div className={styles.templeScheduleContainer} id="detail-section-2">
       <DetailTitle title="프로그램 일정" isTotal={false} />
       {parsedSchedule ? (
         Object.entries(parsedSchedule).map(([day, programs]) => (

--- a/src/components/templeDetail/templeTitle/TempleTitle.tsx
+++ b/src/components/templeDetail/templeTitle/TempleTitle.tsx
@@ -17,7 +17,7 @@ const TempleTitle = ({ tag, templeName, templestayName }: TempleTitleProps) => {
         ))}
       </div>
       <div className={styles.templeNameBox}>
-        <h1 className={styles.templeNameContext}>
+        <h1>
           {templeName} {templestayName}
         </h1>
       </div>

--- a/src/components/templeDetail/templeTitle/templeTitle.css.ts
+++ b/src/components/templeDetail/templeTitle/templeTitle.css.ts
@@ -5,7 +5,8 @@ export const titleWrapper = style({
   display: 'flex',
   flexDirection: 'column',
   width: '33.5rem',
-  height: '5rem',
+  minHeight: '5rem',
+  maxHeight: '10.6rem',
   gap: '0.4rem',
 });
 
@@ -18,10 +19,4 @@ export const tagBox = style({
 
 export const templeNameBox = style({
   ...theme.FONTS.h2Sb20,
-});
-
-export const templeNameContext = style({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
 });

--- a/src/components/templeDetail/templeTopbar/templeTopbar.css.ts
+++ b/src/components/templeDetail/templeTopbar/templeTopbar.css.ts
@@ -1,9 +1,0 @@
-import { style } from '@vanilla-extract/css';
-
-const topbarWrapper = style({
-  position: 'fixed',
-  top: 0,
-  marginTop: '1.2rem',
-});
-
-export default topbarWrapper;

--- a/src/hooks/useMoveScroll.ts
+++ b/src/hooks/useMoveScroll.ts
@@ -1,12 +1,15 @@
 import { useCallback } from 'react';
 
-const useMoveScroll = (headerHeight: number = 0) => {
+const useMoveScroll = (type: string, headerHeight: number = 0) => {
   const scrollToElement = useCallback(
     async (sectionIds: string[], activeIndex: number): Promise<void> => {
       const targetElement = document.getElementById(sectionIds[activeIndex]);
 
       if (targetElement) {
-        const elementPosition = targetElement.getBoundingClientRect().top; // 요소의 현재 화면 내 위치
+        const elementPosition =
+          type === 'detail'
+            ? targetElement.getBoundingClientRect().bottom
+            : targetElement.getBoundingClientRect().top; // 요소의 현재 화면 내 위치
         const offsetPosition = window.scrollY + elementPosition - headerHeight; // 동일한 위치 계산
 
         window.scrollTo({
@@ -19,7 +22,7 @@ const useMoveScroll = (headerHeight: number = 0) => {
         });
       }
     },
-    [headerHeight],
+    [type, headerHeight],
   );
 
   return scrollToElement;

--- a/src/pages/searchResultPage/searchResultPage.css.ts
+++ b/src/pages/searchResultPage/searchResultPage.css.ts
@@ -10,6 +10,16 @@ export const container = style({
 export const headerContainer = style({
   boxShadow: theme.COLORS.filerDropshadow,
   backgroundColor: theme.COLORS.white,
+  position: 'fixed',
+  top: 0,
+  width: '37.5rem',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  paddingTop: '1rem',
+  marginBottom: '1rem',
+  zIndex: 5,
 });
 
 export const bodyContainer = style({
@@ -17,7 +27,7 @@ export const bodyContainer = style({
   gridTemplateRows: '1fr auto',
   justifyItems: 'center',
   minHeight: 'calc(100vh - 12.2rem)',
-  paddingTop: '2rem',
+  paddingTop: '12.2rem',
   paddingBottom: '4.4rem',
   gap: '3.2rem',
 });

--- a/src/pages/templeDetailPage/blogReview/BlogReviewPage.tsx
+++ b/src/pages/templeDetailPage/blogReview/BlogReviewPage.tsx
@@ -48,7 +48,9 @@ const BlogReviewPage = () => {
 
   return (
     <div className={styles.reviewWrapper}>
-      <PageName title={`블로그 리뷰 (${reviewCount}개)`} isLikeBtn={false} />
+      <div className={styles.headerBox}>
+        <PageName title={`블로그 리뷰 (${reviewCount}개)`} isLikeBtn={false} />
+      </div>
       <div className={styles.reviewComponent}>
         {data.reviews && data.reviews.length > 0 ? (
           data.reviews.map((review) => (

--- a/src/pages/templeDetailPage/blogReview/blogReviewPage.css.ts
+++ b/src/pages/templeDetailPage/blogReview/blogReviewPage.css.ts
@@ -1,10 +1,25 @@
+import theme from '@styles/theme.css';
 import { style } from '@vanilla-extract/css';
+
+export const headerBox = style({
+  position: 'fixed',
+  top: 0,
+  width: '37.5rem',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  paddingTop: '1rem',
+  marginBottom: '1rem',
+  zIndex: 2,
+  backgroundColor: theme.COLORS.white,
+});
 
 export const reviewComponent = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '1.2rem',
   overflow: 'hidden',
+  paddingTop: '5rem',
 });
 
 export const reviewWrapper = style({

--- a/src/pages/templeDetailPage/templeDetailPage.css.ts
+++ b/src/pages/templeDetailPage/templeDetailPage.css.ts
@@ -12,6 +12,7 @@ export const templeDetailWrapper = style({
 export const headerBox = style({
   position: 'fixed',
   top: 0,
+  paddingTop: '1.2rem',
   width: '37.5rem',
   display: 'flex',
   justifyContent: 'center',

--- a/src/pages/templeDetailPage/templeDetailPage.css.ts
+++ b/src/pages/templeDetailPage/templeDetailPage.css.ts
@@ -12,7 +12,6 @@ export const templeDetailWrapper = style({
 export const headerBox = style({
   position: 'fixed',
   top: 0,
-  paddingTop: '1.2rem',
   width: '37.5rem',
   display: 'flex',
   justifyContent: 'center',

--- a/src/pages/templeDetailPage/templePhoto/TemplePhotoPage.tsx
+++ b/src/pages/templeDetailPage/templePhoto/TemplePhotoPage.tsx
@@ -23,7 +23,9 @@ const TemplePhotoPage = () => {
 
   return (
     <div className={styles.photoContainer}>
-      <PageName title="사진" isLikeBtn={false} />
+      <div className={styles.headerBox}>
+        <PageName title="사진" isLikeBtn={false} />
+      </div>
       <div className={styles.photoGrid}>
         {data.templestayImgs.map((photo) => (
           <img

--- a/src/pages/templeDetailPage/templePhoto/templePhotoPage.css.ts
+++ b/src/pages/templeDetailPage/templePhoto/templePhotoPage.css.ts
@@ -1,4 +1,18 @@
+import theme from '@styles/theme.css';
 import { style } from '@vanilla-extract/css';
+
+export const headerBox = style({
+  position: 'fixed',
+  top: 0,
+  width: '37.5rem',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  paddingTop: '1rem',
+  marginBottom: '1rem',
+  zIndex: 2,
+  backgroundColor: theme.COLORS.white,
+});
 
 export const photoContainer = style({
   display: 'flex',


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #208 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 상세페이지 사찰 이미지 null일시 대체 이미지 처리했습니다.
- 상세페이지 전화번호 줄 넘어갈시 ... 대체했습니다.
- 큐레이션 클릭시 페이지 상단으로 스크롤하도록 했습니다.
- 탭바 스크롤을 type에 따라 
`.getBoundingClientRect().bottom` `.getBoundingClientRect().top`로 각각 다르게 적용되도록 하여 상세페이지에서 보다 알맞게 움직이도록 적용했습니다.
- 블로그, 사진, 큐레이션, 사찰 검색 뷰 탑바 상단 고정했습니다.

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 상단 탑바가 공통 컴포넌트이긴 한데 이미 상단 고정을 적용한 것도 있고 각각 다르게 페이지에서 적용되어 있어서 공통으로 못빼고 각자 적용시켰는데 추후에 리팩토링하겠습니다 죄송합니다🥹🥹🥹🥹🥹🥹🥹

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->