### PR TITLE
[FIX] 캐러셀 드래그 인터랙션 문제 해결

### DIFF
--- a/src/components/card/popularCard/PopularCard.tsx
+++ b/src/components/card/popularCard/PopularCard.tsx
@@ -44,7 +44,11 @@ const PopularCard = ({
   };
 
   return (
-    <a href={link} className={styles.cardWrapper}>
+    <a
+      href={link}
+      className={styles.cardWrapper}
+      draggable={false}
+      onDragStart={(e) => e.preventDefault()}>
       <div>
         <div className={styles.imgBox} style={{ backgroundImage: `url(${templeImg})` }}>
           <RankBtn ranking={ranking} />

--- a/src/components/curation/curationCard/CurationCard.tsx
+++ b/src/components/curation/curationCard/CurationCard.tsx
@@ -9,7 +9,12 @@ interface CurationCardProps {
 
 const CurationCard = ({ bgImage, title, subtitle, link }: CurationCardProps) => {
   return (
-    <a href={link} className={styles.cardContainer} style={{ backgroundImage: `url(${bgImage})` }}>
+    <a
+      href={link}
+      className={styles.cardContainer}
+      style={{ backgroundImage: `url(${bgImage})` }}
+      draggable={false}
+      onDragStart={(e) => e.preventDefault()}>
       <div className={styles.textbox}>
         <p className={styles.title}>{title}</p>
         <p className={styles.subtitle}>{subtitle}</p>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #285

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- <button>에서 <a> 태그로 변경한 이후 캐러셀 드래그 동작 중 터치/클릭 이벤트 간 충돌로 인해 드래그 인터랙션이 매끄럽지 않게 작동하고 있었는데, 이를 해결하기 위해 a태그 기본 동작을 제거해주었습니다

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- `draggable={false}` : 브라우저의 기본 드래그 행동 자체를 차단
- `onDragStart={(e) => e.preventDefault()}` : 드래그 이벤트의 기본 동작 차단

➡️ 둘 다 해주는 이유 
- 일부 브라우저에서는 draggable={false}만으로도 dragstart 이벤트가 발생할 수 있어서 따라서 브라우저의 기본 동작 + 이벤트 자체를 이중으로 차단해서, 캐러셀 드래그와 충돌하지 않도록 방지하기 위함

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->